### PR TITLE
[DOM-108] Add domain as part of GET push contact endpoint route

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -349,7 +349,7 @@ namespace Doppler.PushContact.Test.Controllers
             var fixture = new Fixture();
             var domain = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}")
             {
                 Headers = { { "Authorization", $"Bearer {token}" } }
             };
@@ -372,7 +372,7 @@ namespace Doppler.PushContact.Test.Controllers
             var fixture = new Fixture();
             var domain = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}")
             {
                 Headers = { { "Authorization", $"Bearer {token}" } }
             };
@@ -397,7 +397,7 @@ namespace Doppler.PushContact.Test.Controllers
             var fixture = new Fixture();
             var domain = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}")
             {
                 Headers = { { "Authorization", $"Bearer {token}" } }
             };
@@ -419,7 +419,7 @@ namespace Doppler.PushContact.Test.Controllers
             var fixture = new Fixture();
             var domain = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}");
 
             // Act
             var response = await client.SendAsync(request);
@@ -455,7 +455,7 @@ namespace Doppler.PushContact.Test.Controllers
             var domain = fixture.Create<string>();
             var email = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}&email={email}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}?email={email}")
             {
                 Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } }
             };
@@ -510,7 +510,7 @@ namespace Doppler.PushContact.Test.Controllers
             var domain = fixture.Create<string>();
             var email = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}&email={email}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}?email={email}")
             {
                 Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } }
             };
@@ -549,7 +549,7 @@ namespace Doppler.PushContact.Test.Controllers
             var domain = fixture.Create<string>();
             var email = fixture.Create<string>();
 
-            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts?domain={domain}&email={email}")
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}?email={email}")
             {
                 Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } }
             };

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -32,8 +32,8 @@ namespace Doppler.PushContact.Controllers
         }
 
         [HttpGet]
-        [Route("push-contacts")]
-        public async Task<IActionResult> GetBy([FromQuery] string domain, [FromQuery] string email)
+        [Route("push-contacts/{domain}")]
+        public async Task<IActionResult> GetBy([FromRoute] string domain, [FromQuery] string email)
         {
             var pushContactFilter = new PushContactFilter(domain, email);
 


### PR DESCRIPTION
Related to [DOM-108](https://makingsense.atlassian.net/browse/DOM-108) and [this](https://github.com/FromDoppler/doppler-push-contact/pull/25#discussion_r702963979) comment.

`domain` is a required parameter. To continue with [API definition endpoints definition](https://github.com/FromDoppler/doppler-push-contact/pull/25#discussion_r695990165) I include `domain` as part of GET push contact endpoint route.