### PR TITLE
[DOM-109] Add from/to modified date filter on GET endpoint

### DIFF
--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -285,7 +285,8 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
 
             var pushContactMongoContextSettings = fixture.Create<PushContactMongoContextSettings>();
 
-            var pushContactFilter = fixture.Create<PushContactFilter>();
+            var domain = fixture.Create<string>();
+            var pushContactFilter = new PushContactFilter(domain);
 
             var pushContactsCollectionMock = new Mock<IMongoCollection<BsonDocument>>();
             pushContactsCollectionMock
@@ -485,8 +486,11 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
                 mongoClient.Object,
                 Options.Create(pushContactMongoContextSettings));
 
+            var domain = fixture.Create<string>();
+            var pushContactFilter = new PushContactFilter(domain);
+
             // Act
-            var result = await sut.GetAsync(fixture.Create<PushContactFilter>());
+            var result = await sut.GetAsync(pushContactFilter);
 
             // Assert
             Assert.True(result.Any());
@@ -545,8 +549,11 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
                 mongoClient.Object,
                 Options.Create(pushContactMongoContextSettings));
 
+            var domain = fixture.Create<string>();
+            var pushContactFilter = new PushContactFilter(domain);
+
             // Act
-            var result = await sut.GetAsync(fixture.Create<PushContactFilter>());
+            var result = await sut.GetAsync(pushContactFilter);
 
             // Assert
             _ = result.ToList();

--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -257,6 +257,27 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
         }
 
         [Fact]
+        public async Task
+            GetAsync_should_throw_argument_exception_when_push_contact_filter_modified_from_is_greater_than_modified_to()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var modifiedFrom = fixture.Create<DateTime>();
+            var modifiedTo = modifiedFrom.AddDays(-1);
+
+            var pushContactFilter = new PushContactFilter(domain: domain, modifiedFrom: modifiedFrom, modifiedTo: modifiedTo);
+
+            var sut = CreateSut();
+
+            // Act
+            // Assert
+            var result = await Assert.ThrowsAsync<ArgumentException>(() => sut.GetAsync(pushContactFilter));
+            Assert.Equal($"'{nameof(pushContactFilter.ModifiedFrom)}' cannot be greater than '{nameof(pushContactFilter.ModifiedTo)}'", result.Message);
+        }
+
+        [Fact]
         public async Task GetAsync_should_throw_exception_and_log_error_when_push_contacts_cannot_be_getter()
         {
             // Arrange

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -33,9 +33,9 @@ namespace Doppler.PushContact.Controllers
 
         [HttpGet]
         [Route("push-contacts")]
-        public async Task<IActionResult> GetBy([FromQuery, Required] string domain, [FromQuery] string email)
+        public async Task<IActionResult> GetBy([FromQuery, Required] string domain, [FromQuery] string email, [FromQuery] DateTime? modifiedFrom, [FromQuery] DateTime? modifiedTo)
         {
-            var pushContactFilter = new PushContactFilter(domain, email);
+            var pushContactFilter = new PushContactFilter(domain, email, modifiedFrom, modifiedTo);
 
             var pushContacts = await _pushContactService.GetAsync(pushContactFilter);
 

--- a/Doppler.PushContact/Services/PushContactFilter.cs
+++ b/Doppler.PushContact/Services/PushContactFilter.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Doppler.PushContact.Services
 {
     public class PushContactFilter
@@ -6,10 +8,16 @@ namespace Doppler.PushContact.Services
 
         public string Email { get; }
 
-        public PushContactFilter(string domain, string email = null)
+        public DateTime? ModifiedFrom { get; }
+
+        public DateTime? ModifiedTo { get; }
+
+        public PushContactFilter(string domain, string email = null, DateTime? modifiedFrom = null, DateTime? modifiedTo = null)
         {
             Domain = domain;
             Email = email;
+            ModifiedFrom = modifiedFrom;
+            ModifiedTo = modifiedTo;
         }
     }
 }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -116,6 +116,12 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
                     $"'{nameof(pushContactFilter.Domain)}' cannot be null or empty", nameof(pushContactFilter.Domain));
             }
 
+            if (pushContactFilter.ModifiedFrom > pushContactFilter.ModifiedTo)
+            {
+                throw new ArgumentException(
+                    $"'{nameof(pushContactFilter.ModifiedFrom)}' cannot be greater than '{nameof(pushContactFilter.ModifiedTo)}'");
+            }
+
             var FilterBuilder = Builders<BsonDocument>.Filter;
 
             var filter = FilterBuilder.Eq(PushContactDocumentDomainPropName, pushContactFilter.Domain);
@@ -123,6 +129,16 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentEmailPropName} can
             if (pushContactFilter.Email != null)
             {
                 filter &= FilterBuilder.Eq(PushContactDocumentEmailPropName, pushContactFilter.Email);
+            }
+
+            if (pushContactFilter.ModifiedFrom != null)
+            {
+                filter &= FilterBuilder.Gte(PushContactDocumentModifiedPropName, pushContactFilter.ModifiedFrom);
+            }
+
+            if (pushContactFilter.ModifiedTo != null)
+            {
+                filter &= FilterBuilder.Lte(PushContactDocumentModifiedPropName, pushContactFilter.ModifiedTo);
             }
 
             filter &= !FilterBuilder.Eq(PushContactDocumentDeletedPropName, true);


### PR DESCRIPTION
Related to [DOM-109](https://makingsense.atlassian.net/browse/DOM-109)

This PR is to include filter by _push contact_ modified date. I will filter that modified date is between `from` and `to` query string params.

Following iterations:
- Sort element by modified date
- Include pagination (maybe _continuation token_)
- Prevent processing the same event (see [this](https://github.com/FromDoppler/doppler-push-contact/pull/25#discussion_r702963979) comment)