### PR TITLE
[DOM-123] Allows anonymous on add/update push contacts endpoints

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -40,7 +40,7 @@ namespace Doppler.PushContact.Test.Controllers
             _output = output;
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_EMPTY)]
         [InlineData(TOKEN_BROKEN)]
         public async Task Add_should_return_unauthorized_when_token_is_not_valid(string token)
@@ -61,7 +61,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
         public async Task Add_should_return_unauthorized_when_token_is_a_expired_superuser_token(string token)
         {
@@ -81,7 +81,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_EXPIRE_20330518)]
         [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
         [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
@@ -103,7 +103,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Now allows anonymous")]
         public async Task Add_should_return_unauthorized_when_authorization_header_is_empty()
         {
             // Arrange
@@ -157,7 +157,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(expectedHttpStatusCode, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_EMPTY)]
         [InlineData(TOKEN_BROKEN)]
         public async Task UpdateEmail_should_return_unauthorized_when_token_is_not_valid(string token)
@@ -184,7 +184,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
         public async Task UpdateEmail_should_return_unauthorized_when_token_is_a_expired_superuser_token(string token)
         {
@@ -210,7 +210,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_EXPIRE_20330518)]
         [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
         [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
@@ -238,7 +238,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Now allows anonymous")]
         public async Task UpdateEmail_should_return_unauthorized_when_authorization_header_is_empty()
         {
             // Arrange

--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -40,6 +40,74 @@ namespace Doppler.PushContact.Test.Controllers
             _output = output;
         }
 
+        [Fact]
+        public async Task Add_should_not_require_token()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "push-contacts")
+            {
+                Content = JsonContent.Create(fixture.Create<PushContactModel>())
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TOKEN_EMPTY)]
+        [InlineData(TOKEN_BROKEN)]
+        [InlineData(TOKEN_EXPIRE_20330518)]
+        [InlineData(TOKEN_SUPERUSER_EXPIRE_20330518)]
+        [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
+        [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
+        [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
+        public async Task Add_should_accept_any_token(string token)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "push-contacts")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } },
+                Content = JsonContent.Create(fixture.Create<PushContactModel>())
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
         [Theory(Skip = "Now allows anonymous")]
         [InlineData(TOKEN_EMPTY)]
         [InlineData(TOKEN_BROKEN)]
@@ -155,6 +223,80 @@ namespace Doppler.PushContact.Test.Controllers
 
             // Assert
             Assert.Equal(expectedHttpStatusCode, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateEmail_should_not_require_token()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var deviceToken = fixture.Create<string>();
+            var email = fixture.Create<string>();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"push-contacts/{deviceToken}/email")
+            {
+                Content = JsonContent.Create(email)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TOKEN_EMPTY)]
+        [InlineData(TOKEN_BROKEN)]
+        [InlineData(TOKEN_EXPIRE_20330518)]
+        [InlineData(TOKEN_SUPERUSER_EXPIRE_20330518)]
+        [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
+        [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
+        [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
+        public async Task UpdateEmail_should_accept_any_token(string token)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var deviceToken = fixture.Create<string>();
+            var email = fixture.Create<string>();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"push-contacts/{deviceToken}/email")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } },
+                Content = JsonContent.Create(email)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Theory(Skip = "Now allows anonymous")]

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -22,6 +22,7 @@ namespace Doppler.PushContact.Controllers
             _pushContactService = pushContactService;
         }
 
+        [AllowAnonymous]
         [HttpPost]
         [Route("push-contacts")]
         public async Task<IActionResult> Add([FromBody] PushContactModel pushContactModel)
@@ -56,6 +57,7 @@ namespace Doppler.PushContact.Controllers
             return Ok(deletedCount);
         }
 
+        [AllowAnonymous]
         [HttpPut]
         [Route("push-contacts/{deviceToken}/email")]
         public async Task<IActionResult> UpdateEmail([FromRoute] string deviceToken, [FromBody] string email)


### PR DESCRIPTION
To use add/update push contacts endpoints from user client we removed authorization in this PR.

**_Important: This PR does not be merged before include device token verification [(DOM-124)](https://makingsense.atlassian.net/browse/DOM-124)._**

Related to [DOM-123](https://makingsense.atlassian.net/browse/DOM-123)
