### PR TITLE
[DOM-131] Message sender implementation (calling PushApi)

### DIFF
--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -1,0 +1,140 @@
+using AutoFixture;
+using Doppler.PushContact.Services.Messages;
+using Doppler.PushContact.Services.Messages.ExternalContracts;
+using Flurl.Http;
+using Flurl.Http.Testing;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.PushContact.Test.Services.Messages
+{
+    public class MessageSenderTest
+    {
+        private static readonly MessageSenderSettings messageSenderSettingsDefault =
+            new MessageSenderSettings
+            {
+                PushApiUrl = "https://localhost:9999",
+                FatalMessagingErrorCodes = new List<int>() { 1, 2, 3, 4 }
+            };
+
+        private static MessageSender CreateSut(
+            IPushApiTokenGetter pushApiTokenGetter = null,
+            IOptions<MessageSenderSettings> messageSenderSettings = null)
+        {
+            return new MessageSender(
+                messageSenderSettings ?? Options.Create(messageSenderSettingsDefault),
+                pushApiTokenGetter ?? Mock.Of<IPushApiTokenGetter>());
+        }
+
+        [Theory]
+        [InlineData(null, "some body", new string[] { "someTargetDeviceTokens" })]
+        [InlineData("some title", null, new string[] { "someTargetDeviceTokens" })]
+        [InlineData("some title", "some body", null)]
+        [InlineData(null, null, null)]
+        [InlineData("some title", "", new string[] { "someTargetDeviceTokens" })]
+        [InlineData("", "some body", new string[] { "someTargetDeviceTokens" })]
+        [InlineData("some title", "some body", new string[] { })]
+        [InlineData("", "", new string[] { })]
+        public async Task
+            SendAsync_should_throw_argument_exception_and_not_have_made_a_http_call_when_title_or_body_or_target_are_null_or_empty(string title, string body, string[] targetDeviceTokens)
+        {
+            // Arrange
+            using var httpTest = new HttpTest();
+
+            var sut = CreateSut();
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<ArgumentException>(() => sut.SendAsync(title, body, targetDeviceTokens));
+            httpTest.ShouldNotHaveMadeACall();
+        }
+
+        [Theory]
+        [InlineData(500)]
+        [InlineData(400)]
+        [InlineData(401)]
+        [InlineData(404)]
+        public async Task SendAsync_should_throw_flurl_http_exception_when_push_api_response_a_not_success_status(int notSuccessStatus)
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var targetDeviceTokens = fixture.CreateMany<string>();
+
+            using var httpTest = new HttpTest();
+
+            httpTest.RespondWithJson(string.Empty, notSuccessStatus);
+
+            var sut = CreateSut();
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<FlurlHttpException>(() => sut.SendAsync(title, body, targetDeviceTokens));
+            httpTest.ShouldHaveCalled($"{messageSenderSettingsDefault.PushApiUrl}/message")
+                .WithVerb(HttpMethod.Post)
+                .Times(1);
+        }
+
+        [Fact]
+        public async Task SendAsync_should_throw_exception_and_does_not_call_push_api_when_push_api_token_getter_throw_exception()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var targetDeviceTokens = fixture.CreateMany<string>();
+
+            using var httpTest = new HttpTest();
+
+            var pushApiTokenGetterMock = new Mock<IPushApiTokenGetter>();
+            pushApiTokenGetterMock
+                .Setup(x => x.GetTokenAsync())
+                .ThrowsAsync(new Exception());
+
+            var sut = CreateSut(
+                pushApiTokenGetter: pushApiTokenGetterMock.Object
+                );
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<Exception>(() => sut.SendAsync(title, body, targetDeviceTokens));
+            httpTest.ShouldNotHaveMadeACall();
+        }
+
+        [Fact]
+        public async Task SendAsync_should_return_only_one_message_target_result_per_push_api_send_message_response()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var targetDeviceTokens = fixture.CreateMany<string>();
+
+            var sendMessageResponse = fixture.Create<SendMessageResponse>();
+
+            using var httpTest = new HttpTest();
+            httpTest.RespondWithJson(sendMessageResponse, 200);
+
+            var sut = CreateSut();
+
+            // Act
+            var sendMessageResult = await sut.SendAsync(title, body, targetDeviceTokens);
+
+            // Assert
+            Assert.All(sendMessageResponse.Responses, x => sendMessageResult.SendMessageTargetResult.Single(y => y.TargetDeviceToken == x.DeviceToken));
+            httpTest.ShouldHaveCalled($"{messageSenderSettingsDefault.PushApiUrl}/message")
+                .WithVerb(HttpMethod.Post)
+                .Times(1);
+        }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponse.cs
+++ b/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.Services.Messages.ExternalContracts
+{
+    public class SendMessageResponse
+    {
+        public List<SendMessageResponseDetail> Responses { get; set; }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponseDetail.cs
+++ b/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponseDetail.cs
@@ -1,0 +1,11 @@
+namespace Doppler.PushContact.Services.Messages.ExternalContracts
+{
+    public class SendMessageResponseDetail
+    {
+        public bool IsSuccess { get; set; }
+
+        public SendMessageResponseException Exception { get; set; }
+
+        public string DeviceToken { get; set; }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponseException.cs
+++ b/Doppler.PushContact/Services/Messages/ExternalContracts/SendMessageResponseException.cs
@@ -1,0 +1,9 @@
+namespace Doppler.PushContact.Services.Messages.ExternalContracts
+{
+    public class SendMessageResponseException
+    {
+        public int MessagingErrorCode { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/IMessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageSender.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public interface IMessageSender
+    {
+        Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens);
+    }
+}

--- a/Doppler.PushContact/Services/Messages/IPushApiTokenGetter.cs
+++ b/Doppler.PushContact/Services/Messages/IPushApiTokenGetter.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public interface IPushApiTokenGetter
+    {
+        Task<string> GetTokenAsync();
+    }
+}

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -1,0 +1,68 @@
+using Doppler.PushContact.Services.Messages.ExternalContracts;
+using Flurl;
+using Flurl.Http;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public class MessageSender : IMessageSender
+    {
+        private readonly MessageSenderSettings _messageSenderSettings;
+        private readonly IPushApiTokenGetter _pushApiTokenGetter;
+
+        public MessageSender(IOptions<MessageSenderSettings> messageSenderSettings, IPushApiTokenGetter pushApiTokenGetter)
+        {
+            _messageSenderSettings = messageSenderSettings.Value;
+            _pushApiTokenGetter = pushApiTokenGetter;
+        }
+
+        public async Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens)
+        {
+            if (string.IsNullOrEmpty(title))
+            {
+                throw new ArgumentException($"'{nameof(title)}' cannot be null or empty.", nameof(title));
+            }
+
+            if (string.IsNullOrEmpty(body))
+            {
+                throw new ArgumentException($"'{nameof(body)}' cannot be null or empty.", nameof(body));
+            }
+
+            if (targetDeviceTokens == null || !targetDeviceTokens.Any())
+            {
+                throw new ArgumentException($"'{nameof(targetDeviceTokens)}' cannot be null or empty.", nameof(targetDeviceTokens));
+            }
+
+            // TODO: use adhock token here.
+            // It is recovering our client API request to be resusen to request to Push API,
+            // but maybe it will not be acceptable in all scenarios.
+            var pushApiToken = await _pushApiTokenGetter.GetTokenAsync();
+
+            var responseBody = await _messageSenderSettings.PushApiUrl
+                .AppendPathSegment("message")
+                .WithOAuthBearerToken(pushApiToken)
+                .PostJsonAsync(new
+                {
+                    notificationTitle = title,
+                    notificationBody = body,
+                    tokens = targetDeviceTokens
+                })
+                .ReceiveJson<SendMessageResponse>();
+
+            return new SendMessageResult
+            {
+                SendMessageTargetResult = responseBody.Responses.Select(x => new SendMessageTargetResult
+                {
+                    TargetDeviceToken = x.DeviceToken,
+                    IsSuccess = x.IsSuccess,
+                    IsValidTargetDeviceToken = !x.IsSuccess && _messageSenderSettings.FatalMessagingErrorCodes.Any(y => y == x.Exception.MessagingErrorCode),
+                    NotSuccessErrorDetails = !x.IsSuccess ? $"{nameof(x.Exception.MessagingErrorCode)} {x.Exception.MessagingErrorCode} - {nameof(x.Exception.Message)} {x.Exception.Message}" : null
+                })
+            };
+        }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/MessageSenderSettings.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSenderSettings.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public class MessageSenderSettings
+    {
+        public string PushApiUrl { get; set; }
+
+        public List<int> FatalMessagingErrorCodes { get; set; }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/PushApiTokenGetter.cs
+++ b/Doppler.PushContact/Services/Messages/PushApiTokenGetter.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public class PushApiTokenGetter : IPushApiTokenGetter
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public PushApiTokenGetter(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<string> GetTokenAsync()
+        {
+            return await _httpContextAccessor.HttpContext.GetTokenAsync("Bearer", "access_token");
+        }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/SendMessageResult.cs
+++ b/Doppler.PushContact/Services/Messages/SendMessageResult.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public class SendMessageResult
+    {
+        public IEnumerable<SendMessageTargetResult> SendMessageTargetResult { get; set; }
+    }
+}

--- a/Doppler.PushContact/Services/Messages/SendMessageTargetResult.cs
+++ b/Doppler.PushContact/Services/Messages/SendMessageTargetResult.cs
@@ -1,0 +1,13 @@
+namespace Doppler.PushContact.Services.Messages
+{
+    public class SendMessageTargetResult
+    {
+        public string TargetDeviceToken { get; set; }
+
+        public bool IsSuccess { get; set; }
+
+        public bool IsValidTargetDeviceToken { get; set; }
+
+        public string NotSuccessErrorDetails { get; set; }
+    }
+}


### PR DESCRIPTION
This PR contains the implementation of the [PushApi](https://github.com/FromDoppler/doppler-push-api) call to send push notifications. This will be used in the following use case:
![image](https://user-images.githubusercontent.com/75738115/135101565-a8700e89-4dbd-4929-8cab-cd55ea8832d5.png)

- [X] I will include an extra tests in this PR

Related to [DOM-131](https://makingsense.atlassian.net/browse/DOM-131).
