### PR TITLE
[DOM-132] Add push contact history events after sent message

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -1214,5 +1214,152 @@ namespace Doppler.PushContact.Test.Controllers
                 .Verify(x => x.DeleteByDeviceTokenAsync(
                     It.Is<IEnumerable<string>>(y => y.All(z => sendMessageResult.SendMessageTargetResult.Any(w => w.TargetDeviceToken == z && !w.IsValidTargetDeviceToken)))), Times.Once());
         }
+
+        [Fact]
+        public async Task
+            Message_should_does_not_call_AddHistoryEventsAsync_when_message_sender_returned_a_empty_target_result_collection()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var sendMessageResult = new SendMessageResult
+            {
+                SendMessageTargetResult = Enumerable.Empty<SendMessageTargetResult>()
+            };
+
+            var messageSenderMock = new Mock<IMessageSender>();
+            messageSenderMock
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(sendMessageResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var domain = fixture.Create<string>();
+            var message = new Message
+            {
+                Title = fixture.Create<string>(),
+                Body = fixture.Create<string>()
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(message)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            pushContactServiceMock
+                .Verify(x => x.AddHistoryEventsAsync(It.IsAny<IEnumerable<PushContactHistoryEvent>>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task
+            Message_should_does_not_call_AddHistoryEventsAsync_when_message_sender_returned_a_null_target_result_collection()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var sendMessageResult = new SendMessageResult
+            {
+                SendMessageTargetResult = null
+            };
+
+            var messageSenderMock = new Mock<IMessageSender>();
+            messageSenderMock
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(sendMessageResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var domain = fixture.Create<string>();
+            var message = new Message
+            {
+                Title = fixture.Create<string>(),
+                Body = fixture.Create<string>()
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(message)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            pushContactServiceMock
+                .Verify(x => x.AddHistoryEventsAsync(It.IsAny<IEnumerable<PushContactHistoryEvent>>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task Message_should_call_AddHistoryEventsAsync_with_all_target_device_tokens_returned_by_message_sender()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+
+            var sendMessageResult = new SendMessageResult
+            {
+                SendMessageTargetResult = fixture.CreateMany<SendMessageTargetResult>(10)
+            };
+
+            var messageSenderMock = new Mock<IMessageSender>();
+            messageSenderMock
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .ReturnsAsync(sendMessageResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
+                });
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var domain = fixture.Create<string>();
+            var message = new Message
+            {
+                Title = fixture.Create<string>(),
+                Body = fixture.Create<string>()
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(message)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            pushContactServiceMock
+                .Verify(x => x.AddHistoryEventsAsync(
+                It.Is<IEnumerable<PushContactHistoryEvent>>(x => sendMessageResult.SendMessageTargetResult.All(y => x.Any(z => z.DeviceToken == y.TargetDeviceToken)))), Times.Once());
+        }
     }
 }

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -88,8 +88,27 @@ namespace Doppler.PushContact.Controllers
                 await _pushContactService.DeleteByDeviceTokenAsync(notValidTargetDeviceToken);
             }
 
-            // TODO: add history events related to sent messages,
-            // response a MessageId and run all steps asynchronous
+            var now = DateTime.UtcNow;
+
+            var pushContactHistoryEvents = sendMessageResult
+                .SendMessageTargetResult?
+                    .Select(x =>
+                    {
+                        return new PushContactHistoryEvent
+                        {
+                            DeviceToken = x.TargetDeviceToken,
+                            SentSuccess = x.IsSuccess,
+                            EventDate = now,
+                            Details = x.NotSuccessErrorDetails
+                        };
+                    });
+
+            if (pushContactHistoryEvents != null && pushContactHistoryEvents.Any())
+            {
+                await _pushContactService.AddHistoryEventsAsync(pushContactHistoryEvents);
+            }
+
+            // TODO: response a MessageId and run all steps asynchronous
 
             throw new NotImplementedException();
         }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -209,7 +209,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
                         { PushContactDocumentProps.HistoryEvents_SentSuccessPropName, x.SentSuccess },
                         { PushContactDocumentProps.HistoryEvents_EventDatePropName, x.EventDate },
                         { PushContactDocumentProps.HistoryEvents_InsertedDatePropName, now },
-                        { PushContactDocumentProps.HistoryEvents_DetailsPropName, x.Details }
+                        { PushContactDocumentProps.HistoryEvents_DetailsPropName, string.IsNullOrEmpty(x.Details) ? BsonNull.Value : x.Details }
                     };
 
                     var filter = Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DeviceTokenPropName, x.DeviceToken);


### PR DESCRIPTION
This PR is to add _history events_ after sent message:
![image](https://user-images.githubusercontent.com/75738115/135469550-837c37a9-2ee8-4b2b-97e7-553c0cd9ed02.png)


Related to [DOM-132](https://makingsense.atlassian.net/browse/DOM-132)