### PR TITLE
[DOM-140] Response 200 status code with a message id in send message endpoint

### DIFF
--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -108,9 +108,13 @@ namespace Doppler.PushContact.Controllers
                 await _pushContactService.AddHistoryEventsAsync(pushContactHistoryEvents);
             }
 
-            // TODO: response a MessageId and run all steps asynchronous
+            // TODO: run all steps asynchronous
+            // and response an 202-accepted with the message id instead
 
-            throw new NotImplementedException();
+            return Ok(new MessageResult
+            {
+                MessageId = Guid.NewGuid()
+            });
         }
     }
 }

--- a/Doppler.PushContact/Models/MessageResult.cs
+++ b/Doppler.PushContact/Models/MessageResult.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Doppler.PushContact.Models
+{
+    public class MessageResult
+    {
+        public Guid MessageId { get; set; }
+    }
+}


### PR DESCRIPTION
After make all send message steps asynchronous We will to response a `202-accepted` status code instead.

- [x] Tinking on tests

Related to [DOM-140](https://makingsense.atlassian.net/browse/DOM-140)