### PR TITLE
[DOM-141] Remove obsolete endpoints

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -733,7 +733,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_EMPTY)]
         [InlineData(TOKEN_BROKEN)]
         public async Task BulkDelete_should_return_unauthorized_when_token_is_not_valid(string token)
@@ -754,7 +754,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
         public async Task BulkDelete_should_return_unauthorized_when_token_is_a_expired_superuser_token(string token)
         {
@@ -774,7 +774,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_EXPIRE_20330518)]
         [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
         [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
@@ -796,7 +796,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkDelete_should_return_unauthorized_when_authorization_header_is_empty()
         {
             // Arrange
@@ -812,7 +812,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkDelete_should_return_ok_and_deleted_count_when_service_does_not_throw_an_exception()
         {
             // Arrange
@@ -851,7 +851,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(deletedCount.ToString(), responseAsString);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkDelete_should_return_internal_server_error_when_service_throw_an_exception()
         {
             // Arrange

--- a/Doppler.PushContact.Test/Controllers/PushContactHistoryEventControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactHistoryEventControllerTest.cs
@@ -38,7 +38,7 @@ namespace Doppler.PushContact.Test.Controllers
             _output = output;
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_EMPTY)]
         [InlineData(TOKEN_BROKEN)]
         public async Task BulkAdd_should_return_unauthorized_when_token_is_not_valid(string token)
@@ -59,7 +59,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_SUPERUSER_EXPIRE_20010908)]
         public async Task BulkAdd_should_return_unauthorized_when_token_is_a_expired_superuser_token(string token)
         {
@@ -79,7 +79,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Theory]
+        [Theory(Skip = "Endpoint removed")]
         [InlineData(TOKEN_EXPIRE_20330518)]
         [InlineData(TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
         [InlineData(TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
@@ -101,7 +101,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkAdd_should_return_unauthorized_when_authorization_header_is_empty()
         {
             // Arrange
@@ -117,7 +117,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkAdd_should_return_ok_when_service_does_not_throw_an_exception()
         {
             // Arrange
@@ -152,7 +152,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "Endpoint removed")]
         public async Task BulkAdd_should_return_internal_server_error_when_service_throw_an_exception()
         {
             // Arrange

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -51,15 +51,6 @@ namespace Doppler.PushContact.Controllers
             return Ok(pushContacts);
         }
 
-        [HttpDelete]
-        [Route("push-contacts/_bulk")]
-        public async Task<IActionResult> BulkDelete([FromBody] IEnumerable<string> deviceTokens)
-        {
-            var deletedCount = await _pushContactService.DeleteByDeviceTokenAsync(deviceTokens);
-
-            return Ok(deletedCount);
-        }
-
         [AllowAnonymous]
         [HttpPut]
         [Route("push-contacts/{deviceToken}/email")]

--- a/Doppler.PushContact/Controllers/PushContactHistoryEventController.cs
+++ b/Doppler.PushContact/Controllers/PushContactHistoryEventController.cs
@@ -18,14 +18,5 @@ namespace Doppler.PushContact.Controllers
         {
             _pushContactService = pushContactService;
         }
-
-        [HttpPost]
-        [Route("history-events/_bulk")]
-        public async Task<IActionResult> BulkAdd([FromBody] IEnumerable<PushContactHistoryEvent> pushContactHistoryEvents)
-        {
-            await _pushContactService.AddHistoryEventsAsync(pushContactHistoryEvents);
-
-            return Ok();
-        }
     }
 }


### PR DESCRIPTION
The deleted endpoints were being called only from _Push Api_. I removed these calls in [this](https://github.com/FromDoppler/doppler-push-api/pull/40) PR.

Related to [DOM-141](https://makingsense.atlassian.net/browse/DOM-141)