### PR TITLE
[DOM-186] Add optional on click link in push message

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -1510,5 +1510,47 @@ namespace Doppler.PushContact.Test.Controllers
             // Assert
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task Message_should_allow_missing_onClickLink_param(string onClickLink)
+        {
+            // Arrange
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var messageSenderMock = new Mock<IMessageSender>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var message = new Message
+            {
+                Title = fixture.Create<string>(),
+                Body = fixture.Create<string>(),
+                OnClickLink = onClickLink
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_SUPERUSER_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(message)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.NotEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
     }
 }

--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -1003,7 +1003,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = title,
-                Body = body
+                Body = body,
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1036,7 +1037,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1052,7 +1053,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1084,7 +1086,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1100,7 +1102,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1132,7 +1135,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1148,7 +1151,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1181,7 +1185,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1197,7 +1201,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1231,7 +1236,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1247,7 +1252,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1280,7 +1286,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1296,7 +1302,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1328,7 +1335,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(sendMessageResult);
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1344,7 +1351,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1383,7 +1391,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ReturnsAsync(fixture.Create<SendMessageResult>());
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1399,7 +1407,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1442,7 +1451,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")
@@ -1468,7 +1478,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var messageSenderMock = new Mock<IMessageSender>();
             messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
+                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>()))
                 .ThrowsAsync(new Exception());
 
             var client = _factory.WithWebHostBuilder(builder =>
@@ -1484,7 +1494,8 @@ namespace Doppler.PushContact.Test.Controllers
             var message = new Message
             {
                 Title = fixture.Create<string>(),
-                Body = fixture.Create<string>()
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>()
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/message")

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -67,7 +67,7 @@ namespace Doppler.PushContact.Controllers
         {
             var deviceTokens = await _pushContactService.GetAllDeviceTokensByDomainAsync(domain);
 
-            var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens);
+            var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink);
 
             var notValidTargetDeviceToken = sendMessageResult
                 .SendMessageTargetResult?

--- a/Doppler.PushContact/Models/Message.cs
+++ b/Doppler.PushContact/Models/Message.cs
@@ -9,5 +9,7 @@ namespace Doppler.PushContact.Models
 
         [Required]
         public string Body { get; set; }
+
+        public string OnClickLink { get; set; }
     }
 }

--- a/Doppler.PushContact/Services/Messages/IMessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageSender.cs
@@ -5,6 +5,6 @@ namespace Doppler.PushContact.Services.Messages
 {
     public interface IMessageSender
     {
-        Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens);
+        Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null);
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -20,7 +20,7 @@ namespace Doppler.PushContact.Services.Messages
             _pushApiTokenGetter = pushApiTokenGetter;
         }
 
-        public async Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens)
+        public async Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null)
         {
             if (string.IsNullOrEmpty(title))
             {
@@ -37,6 +37,12 @@ namespace Doppler.PushContact.Services.Messages
                 throw new ArgumentException($"'{nameof(targetDeviceTokens)}' cannot be null or empty.", nameof(targetDeviceTokens));
             }
 
+            if (!string.IsNullOrEmpty(onClickLink)
+                && (!Uri.TryCreate(onClickLink, UriKind.Absolute, out var onClickLinkResult) || onClickLinkResult.Scheme != Uri.UriSchemeHttps))
+            {
+                throw new ArgumentException($"'{nameof(onClickLink)}' must be an absolute URL with HTTPS scheme.", nameof(onClickLink));
+            }
+
             // TODO: use adhock token here.
             // It is recovering our client API request to be resusen to request to Push API,
             // but maybe it will not be acceptable in all scenarios.
@@ -49,6 +55,7 @@ namespace Doppler.PushContact.Services.Messages
                 {
                     notificationTitle = title,
                     notificationBody = body,
+                    NotificationOnClickLink = onClickLink,
                     tokens = targetDeviceTokens
                 })
                 .ReceiveJson<SendMessageResponse>();

--- a/api-contracts.http
+++ b/api-contracts.http
@@ -20,7 +20,8 @@ Content-Type: application/json
 
 {
   "title": "string",
-  "body": "string"
+  "body": "string",
+  "onClickLink": "string"
 }
 
 ## Success Response Body


### PR DESCRIPTION
This PR allows sending an extra param named _OnClickLink_ in `POST /push-contacts/{domain}/message` method. 

The new _OnClickLink_ param is used to set a link to open when the final user clicks on the Push Notification:

https://user-images.githubusercontent.com/75738115/144899098-76654003-9d18-4ee9-b219-aac493ed40b8.mp4

**In the demonstration, I used _Android_ as OS, _Google Chrome_ as browser, and `https://app.fromdoppler.com/` as _OnClickLink_.**

Related to [DOM-186](https://makingsense.atlassian.net/browse/DOM-186) and https://github.com/FromDoppler/doppler-push-api/pull/54