### PR TITLE
[DOM-325] Get detailed message result

### DIFF
--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -106,6 +106,17 @@ namespace Doppler.PushContact.Controllers
 
             return Ok(new MessageResult(messageId));
         }
+
+        [HttpGet]
+        [Route("push-contacts/{domain}/messages/{messageId}/details")]
+        public async Task<IActionResult> GetDetailedMessageResult([FromRoute] string domain, [FromRoute] Guid messageId)
+        {
+            var historyEvents = await _pushContactService.GetHistoryEventsAsync(domain, messageId);
+
+            return Ok(new DetailedMessageResult(
+                messageId,
+                historyEvents.Count(),
+                historyEvents.Count(x => x.SentSuccess)));
         }
     }
 }

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -104,10 +104,8 @@ namespace Doppler.PushContact.Controllers
             // TODO: run all steps asynchronous
             // and response an 202-accepted with the message id instead
 
-            return Ok(new MessageResult
-            {
-                MessageId = messageId
-            });
+            return Ok(new MessageResult(messageId));
+        }
         }
     }
 }

--- a/Doppler.PushContact/Models/DetailedMessageResult.cs
+++ b/Doppler.PushContact/Models/DetailedMessageResult.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Doppler.PushContact.Models
+{
+    public class DetailedMessageResult : MessageResult
+    {
+        public int Sent { get; }
+
+        public int Delivered { get; }
+
+        public int NotDelivered => Sent - Delivered;
+
+        public DetailedMessageResult(Guid messageId, int sent, int delivered) : base(messageId)
+        {
+            Sent = sent;
+            Delivered = delivered;
+        }
+    }
+}

--- a/Doppler.PushContact/Models/MessageResult.cs
+++ b/Doppler.PushContact/Models/MessageResult.cs
@@ -4,6 +4,11 @@ namespace Doppler.PushContact.Models
 {
     public class MessageResult
     {
-        public Guid MessageId { get; set; }
+        public Guid MessageId { get; }
+
+        public MessageResult(Guid messageId)
+        {
+            MessageId = messageId;
+        }
     }
 }

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -1,4 +1,5 @@
 using Doppler.PushContact.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -17,5 +18,7 @@ namespace Doppler.PushContact.Services
         Task AddHistoryEventsAsync(IEnumerable<PushContactHistoryEvent> pushContactHistoryEvents);
 
         Task<IEnumerable<string>> GetAllDeviceTokensByDomainAsync(string domain);
+
+        Task<IEnumerable<PushContactHistoryEvent>> GetHistoryEventsAsync(string domain, Guid messageId);
     }
 }


### PR DESCRIPTION
This PR includes a new endpoint to obtain a detailed message result by _domain_ and _message id_

Right now, the _detailed_ message result includes :
- Sent
- Delivered
- Not delivered

Related to https://makingsense.atlassian.net/browse/DOM-325