### PR TITLE
Add response cache Headers

### DIFF
--- a/Doppler.PushContact/Controllers/DomainController.cs
+++ b/Doppler.PushContact/Controllers/DomainController.cs
@@ -32,6 +32,7 @@ namespace Doppler.PushContact.Controllers
         [AllowAnonymous]
         [HttpGet]
         [Route("domains/{name}/isPushFeatureEnabled")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 120)]
         public async Task<ActionResult<bool>> GetPushFeatureStatus([FromRoute] string name)
         {
             var domain = await _domainService.GetByNameAsync(name);


### PR DESCRIPTION
With the same request: 
`GET https://apisint.fromdoppler.net/doppler-push-contact/domains/pushint.fromdoppler.net/isPushFeatureEnabled`

**Response without `Cache-Control` header**

<img width="348" alt="no-cache" src="https://user-images.githubusercontent.com/75738115/171926532-433bdd5f-48b2-4593-aeca-7014fa38ad18.PNG">

**Response with `Cache-Control` header**

<img width="360" alt="cache" src="https://user-images.githubusercontent.com/75738115/171926955-7b79933d-ad07-4668-a220-e3c891a3c740.PNG">

![image](https://user-images.githubusercontent.com/75738115/171927735-ee53e568-0fab-45d1-a316-410a7382f11e.png)

![image](https://user-images.githubusercontent.com/75738115/171927965-1b543ae4-c0fe-4acc-a189-4b3d3e75d01e.png)
