### PR TITLE
Add push contact domain as single field index

### DIFF
--- a/Doppler.PushContact/Services/PushMongoContextExtensions.cs
+++ b/Doppler.PushContact/Services/PushMongoContextExtensions.cs
@@ -32,6 +32,11 @@ namespace Doppler.PushContact.Services
                     new CreateIndexOptions { Unique = true });
                     pushContacts.Indexes.CreateOne(deviceTokenAsUniqueIndex);
 
+                    var domainAsSingleFieldIndex = new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys.Ascending(PushContactDocumentProps.DomainPropName),
+                    new CreateIndexOptions { Unique = false });
+                    pushContacts.Indexes.CreateOne(domainAsSingleFieldIndex);
+
                     var domains = database.GetCollection<BsonDocument>(pushMongoContextSettings.DomainsCollectionName);
 
                     var domainNameAsUniqueIndex = new CreateIndexModel<BsonDocument>(


### PR DESCRIPTION
The reason is that we have _find_ operations in the _push-contacts_ collection filter by _domain_ field. I think that this is a good and inexpensive idea