### PR TITLE
[DOM-87] - Allow extra parameters in connection string

### DIFF
--- a/Doppler.PushContact/Services/PushMongoContextExtensions.cs
+++ b/Doppler.PushContact/Services/PushMongoContextExtensions.cs
@@ -17,13 +17,17 @@ namespace Doppler.PushContact.Services
             var pushMongoContextSettings = new PushMongoContextSettings();
             pushMongoContextSettingsSection.Bind(pushMongoContextSettings);
 
-            var mongoClientSettings = MongoClientSettings.FromConnectionString(
-                $"mongodb+srv://{pushMongoContextSettings.Username}:{pushMongoContextSettings.Password}@{pushMongoContextSettings.Host}");
+            var mongoUrlBuilder = new MongoUrlBuilder(pushMongoContextSettings.ConnectionString)
+            {
+                Password = pushMongoContextSettings.Password,
+                DatabaseName = pushMongoContextSettings.DatabaseName
+            };
+
+            var mongoUrl = mongoUrlBuilder.ToMongoUrl();
 
             services.AddSingleton<IMongoClient>(x =>
                 {
-                    var mongoClient = new MongoClient(mongoClientSettings);
-
+                    var mongoClient = new MongoClient(mongoUrl);
                     var database = mongoClient.GetDatabase(pushMongoContextSettings.DatabaseName);
                     var pushContacts = database.GetCollection<BsonDocument>(pushMongoContextSettings.PushContactsCollectionName);
 

--- a/Doppler.PushContact/Services/PushMongoContextSettings.cs
+++ b/Doppler.PushContact/Services/PushMongoContextSettings.cs
@@ -2,9 +2,7 @@ namespace Doppler.PushContact.Services
 {
     public class PushMongoContextSettings
     {
-        public string Host { get; set; }
-
-        public string Username { get; set; }
+        public string ConnectionString { get; set; }
 
         public string Password { get; set; }
 

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -17,8 +17,7 @@
     "PublicKeysFilenameRegex": "\\.xml$"
   },
   "PushMongoContextSettings": {
-    "Host": "REPLACE_WITH_MONGODB_HOST",
-    "Username": "REPLACE_WITH_MONGODB_USERNAME",
+    "ConnectionString": "mongodb+srv://USERNAME@HOST",
     "Password": "REPLACE_WITH_MONGODB_PASSWORD",
     "DatabaseName": "REPLACE_WITH_MONGODB_DATABASE_NAME",
     "PushContactsCollectionName": "REPLACE_WITH_MONGODB_PUSH_CONTACTS_COLLECTION_NAME",


### PR DESCRIPTION
## Background
We had the connection string hardcoded in PushMongoExtensions.cs, that was a problem because we couldn't add extra parameters without changing the code.

## Summary
With the new changes we have the connection string in the appsettings.json, this allows to add extra parameters without changing the code. Also we used MongoClientSettings to create the url and now i change it to MongoUrlBuilder.
I removed Username and Host from the appsetting because are not necessary any more.
I had to change appsettings file, so i had to change doppler-swarm too, these changes are in the next pr.
Related PR: https://github.com/MakingSense/doppler-swarm/pull/664