### PR TITLE
[DOP-1159] - Update old push contacts

### DIFF
--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -362,6 +362,43 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             await sut.UpdateEmailAsync(deviceToken, email);
         }
 
+        [Fact]
+        public async Task UpdatePushContactVisitorGuid_should_not_throw_exception_when_push_contact_model_can_be_updated()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var deviceToken = fixture.Create<string>();
+            var visitorGuid = fixture.Create<string>();
+
+            var updateResultMock = new Mock<UpdateResult>();
+
+            var pushMongoContextSettings = fixture.Create<PushMongoContextSettings>();
+
+            var pushContactsCollection = new Mock<IMongoCollection<BsonDocument>>();
+            pushContactsCollection
+                .Setup(x => x.UpdateOneAsync(It.IsAny<FilterDefinition<BsonDocument>>(), It.IsAny<UpdateDefinition<BsonDocument>>(), default, default))
+                .ReturnsAsync(updateResultMock.Object);
+
+            var mongoDatabase = new Mock<IMongoDatabase>();
+            mongoDatabase
+                .Setup(x => x.GetCollection<BsonDocument>(pushMongoContextSettings.PushContactsCollectionName, null))
+                .Returns(pushContactsCollection.Object);
+
+            var mongoClient = new Mock<IMongoClient>();
+            mongoClient
+                .Setup(x => x.GetDatabase(pushMongoContextSettings.DatabaseName, null))
+                .Returns(mongoDatabase.Object);
+
+            var sut = CreateSut(
+                mongoClient.Object,
+                Options.Create(pushMongoContextSettings));
+
+            // Act
+            // Assert
+            await sut.UpdatePushContactVisitorGuid(deviceToken, visitorGuid);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -54,6 +54,24 @@ namespace Doppler.PushContact.Controllers
             return Ok(pushContacts);
         }
 
+        [HttpPut]
+        [Route("/push-contacts/{deviceToken}/visitor-guid")]
+        public async Task<IActionResult> UpdatePushContactVisitorGuid([FromRoute] string deviceToken, [FromBody] string visitorGuid)
+        {
+            if (string.IsNullOrEmpty(deviceToken) || string.IsNullOrWhiteSpace(deviceToken))
+            {
+                return BadRequest($"'{nameof(deviceToken)}' cannot be null, empty or whitespace.");
+            }
+
+            if (string.IsNullOrEmpty(visitorGuid) || string.IsNullOrWhiteSpace(visitorGuid))
+            {
+                return BadRequest($"'{nameof(visitorGuid)}' cannot be null, empty or whitespace.");
+            }
+
+            await _pushContactService.UpdatePushContactVisitorGuid(deviceToken, visitorGuid);
+            return Ok();
+        }
+
         [AllowAnonymous]
         [HttpPut]
         [Route("push-contacts/{deviceToken}/email")]

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -23,6 +23,8 @@ namespace Doppler.PushContact.Services
 
         Task<ApiPage<DomainInfo>> GetDomains(int page, int per_page);
 
+        Task UpdatePushContactVisitorGuid(string deviceToken, string visitorGuid);
+
         Task<ApiPage<string>> GetAllVisitorGuidByDomain(string domain, int page, int per_page);
     }
 }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -373,6 +373,26 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
+        public async Task UpdatePushContactVisitorGuid(string deviceToken, string visitorGuid)
+        {
+            try
+            {
+                var filterBuilder = Builders<BsonDocument>.Filter;
+
+                var filter = filterBuilder.Eq(PushContactDocumentProps.DeviceTokenPropName, deviceToken)
+                    & filterBuilder.Eq(PushContactDocumentProps.DeletedPropName, false);
+
+                var updateDefinition = Builders<BsonDocument>.Update
+                .Set(PushContactDocumentProps.VisitorGuidPropName, visitorGuid);
+
+                await PushContacts.UpdateOneAsync(filter, updateDefinition);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"An error occurred updating visitor-guid: {visitorGuid} for the push contact with the {nameof(deviceToken)} {deviceToken}", ex);
+            }
+        }
+
         public async Task<ApiPage<string>> GetAllVisitorGuidByDomain(string domain, int page, int per_page)
         {
             var filterBuilder = Builders<BsonDocument>.Filter;


### PR DESCRIPTION
## Summary
- Now we can update all the old push contacts adding visitor_guid  if they have the deleted flag in false

### Related links
- Jira task: [DOP-1159](https://makingsense.atlassian.net/browse/DOP-1159)
- #177 
- #178 
- #181 