### PR TITLE
Dop 1171 add endpoint to create a new message

### DIFF
--- a/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using Doppler.PushContact.Models;
 using Doppler.PushContact.Services;
+using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Test.Controllers.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -326,6 +327,157 @@ namespace Doppler.PushContact.Test.Controllers
 
             // Assert
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TestApiUsersData.TOKEN_EMPTY)]
+        [InlineData(TestApiUsersData.TOKEN_BROKEN)]
+        public async Task CreateMessageAssociatedToDomain_should_return_unauthorized_when_token_is_not_valid(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var fixture = new Fixture();
+            var name = fixture.Create<string>();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{name}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TestApiUsersData.TOKEN_SUPERUSER_EXPIRE_20010908)]
+        public async Task CreateMessageAssociatedToDomain_should_return_unauthorized_when_token_is_a_expired_superuser_token(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var fixture = new Fixture();
+            var name = fixture.Create<string>();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{name}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(TestApiUsersData.TOKEN_EXPIRE_20330518)]
+        [InlineData(TestApiUsersData.TOKEN_SUPERUSER_FALSE_EXPIRE_20330518)]
+        [InlineData(TestApiUsersData.TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518)]
+        public async Task CreateMessageAssociatedToDomain_should_require_a_valid_token_with_isSU_flag(string token)
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var fixture = new Fixture();
+            var name = fixture.Create<string>();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{name}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {token}" } }
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateMessageAssociatedToDomain_should_return_unauthorized_when_authorization_header_is_empty()
+        {
+            // Arrange
+            var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+            var fixture = new Fixture();
+            var name = fixture.Create<string>();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{name}/message");
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreateMessageAssociatedToDomain_should_create_a_message_with_summarization_fields_equal_cero_and_return_proper_messageId()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var qSent = 0;
+            var qDelivery = 0;
+            var qNotDelivery = 0;
+
+            var domain = "aTestDomain";
+            var message = new Message
+            {
+                Title = fixture.Create<string>(),
+                Body = fixture.Create<string>(),
+                OnClickLink = fixture.Create<string>(),
+                ImageUrl = fixture.Create<string>()
+            };
+
+            var domainServiceMock = new Mock<IDomainService>();
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(domainServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{domain}/message")
+            {
+                Headers = { { "Authorization", $"Bearer {TestApiUsersData.TOKEN_SUPERUSER_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(message)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            messageRepositoryMock.Verify(mock => mock.AddAsync(
+                It.IsAny<Guid>(),
+                domain,
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                qSent,
+                qDelivery,
+                qNotDelivery,
+                It.IsAny<string>()
+            ), Times.Once());
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var messageResult = await response.Content.ReadFromJsonAsync<MessageResult>();
+            Assert.IsType<Guid>(messageResult.MessageId);
         }
     }
 }

--- a/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
@@ -134,11 +134,16 @@ namespace Doppler.PushContact.Test.Controllers
                 .Setup(x => x.UpsertAsync(It.IsAny<Domain>()))
                 .Returns(Task.CompletedTask);
 
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+            var messageSenderMock = new Mock<IMessageSender>();
+
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(domainServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -207,11 +212,16 @@ namespace Doppler.PushContact.Test.Controllers
             domainServiceMock.Setup(x => x.GetByNameAsync(It.IsAny<string>()))
                 .ReturnsAsync(domain);
 
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+            var messageSenderMock = new Mock<IMessageSender>();
+
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(domainServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -241,11 +251,16 @@ namespace Doppler.PushContact.Test.Controllers
             domainServiceMock.Setup(x => x.GetByNameAsync(name))
                 .ReturnsAsync(domain);
 
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+            var messageSenderMock = new Mock<IMessageSender>();
+
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(domainServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -276,11 +291,16 @@ namespace Doppler.PushContact.Test.Controllers
             domainServiceMock.Setup(x => x.GetByNameAsync(name))
                 .ReturnsAsync(domain);
 
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+            var messageSenderMock = new Mock<IMessageSender>();
+
             var client = _factory.WithWebHostBuilder(builder =>
             {
                 builder.ConfigureTestServices(services =>
                 {
                     services.AddSingleton(domainServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());

--- a/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
@@ -482,7 +482,7 @@ namespace Doppler.PushContact.Test.Controllers
         }
 
         [Fact]
-        public async Task CreateMessageAssociatedToDomain_should_return_internal_server_error_when_messageSender_throw_an_exception()
+        public async Task CreateMessageAssociatedToDomain_should_return_UnprocessableEntity_error_when_messageSender_throw_an_exception()
         {
             // Arrange
             var fixture = new Fixture();
@@ -523,7 +523,7 @@ namespace Doppler.PushContact.Test.Controllers
             _output.WriteLine(response.GetHeadersAsString());
 
             // Assert
-            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
         }
     }
 }

--- a/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
@@ -441,6 +441,7 @@ namespace Doppler.PushContact.Test.Controllers
 
             var domainServiceMock = new Mock<IDomainService>();
             var messageRepositoryMock = new Mock<IMessageRepository>();
+            var messageSenderMock = new Mock<IMessageSender>();
 
             var client = _factory.WithWebHostBuilder(builder =>
             {
@@ -448,8 +449,8 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(messageRepositoryMock.Object);
+                    services.AddSingleton(messageSenderMock.Object);
                 });
-
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"domains/{domain}/message")

--- a/Doppler.PushContact/Controllers/DomainController.cs
+++ b/Doppler.PushContact/Controllers/DomainController.cs
@@ -1,6 +1,7 @@
 using Doppler.PushContact.DopplerSecurity;
 using Doppler.PushContact.Models;
 using Doppler.PushContact.Services;
+using Doppler.PushContact.Services.Messages;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
@@ -13,10 +14,12 @@ namespace Doppler.PushContact.Controllers
     public class DomainController : ControllerBase
     {
         private readonly IDomainService _domainService;
+        private readonly IMessageRepository _messageRepository;
 
-        public DomainController(IDomainService domainService)
+        public DomainController(IDomainService domainService, IMessageRepository messageRepository)
         {
             _domainService = domainService;
+            _messageRepository = messageRepository;
         }
 
         [HttpPut]
@@ -43,6 +46,20 @@ namespace Doppler.PushContact.Controllers
             }
 
             return domain.IsPushFeatureEnabled;
+        }
+
+        [HttpPost]
+        [Route("domains/{name}/message")]
+        public async Task<IActionResult> CreateMessageAssociatedToDomain([FromRoute] string name, [FromBody] Message message)
+        {
+            var messageId = Guid.NewGuid();
+
+            await _messageRepository.AddAsync(messageId, name, message.Title, message.Body, message.OnClickLink, 0, 0, 0, message.ImageUrl);
+
+            return Ok(new MessageResult
+            {
+                MessageId = messageId
+            });
         }
     }
 }

--- a/Doppler.PushContact/Controllers/DomainController.cs
+++ b/Doppler.PushContact/Controllers/DomainController.cs
@@ -54,8 +54,14 @@ namespace Doppler.PushContact.Controllers
         [Route("domains/{name}/message")]
         public async Task<IActionResult> CreateMessageAssociatedToDomain([FromRoute] string name, [FromBody] Message message)
         {
-            // TODO: treat error and return a proper error message
-            _messageSender.ValidateMessage(message.Title, message.Body, message.OnClickLink, message.ImageUrl);
+            try
+            {
+                _messageSender.ValidateMessage(message.Title, message.Body, message.OnClickLink, message.ImageUrl);
+            }
+            catch (ArgumentException argExc)
+            {
+                return UnprocessableEntity(argExc.Message);
+            }
 
             var messageId = Guid.NewGuid();
 

--- a/Doppler.PushContact/Controllers/DomainController.cs
+++ b/Doppler.PushContact/Controllers/DomainController.cs
@@ -15,11 +15,13 @@ namespace Doppler.PushContact.Controllers
     {
         private readonly IDomainService _domainService;
         private readonly IMessageRepository _messageRepository;
+        private readonly IMessageSender _messageSender;
 
-        public DomainController(IDomainService domainService, IMessageRepository messageRepository)
+        public DomainController(IDomainService domainService, IMessageRepository messageRepository, IMessageSender messageSender)
         {
             _domainService = domainService;
             _messageRepository = messageRepository;
+            _messageSender = messageSender;
         }
 
         [HttpPut]
@@ -52,6 +54,9 @@ namespace Doppler.PushContact.Controllers
         [Route("domains/{name}/message")]
         public async Task<IActionResult> CreateMessageAssociatedToDomain([FromRoute] string name, [FromBody] Message message)
         {
+            // TODO: treat error and return a proper error message
+            _messageSender.ValidateMessage(message.Title, message.Body, message.OnClickLink, message.ImageUrl);
+
             var messageId = Guid.NewGuid();
 
             await _messageRepository.AddAsync(messageId, name, message.Title, message.Body, message.OnClickLink, 0, 0, 0, message.ImageUrl);

--- a/Doppler.PushContact/Services/Messages/IMessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageSender.cs
@@ -6,5 +6,7 @@ namespace Doppler.PushContact.Services.Messages
     public interface IMessageSender
     {
         Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null, string imageUrl = null);
+
+        void ValidateMessage(string title, string body, string onClickLink, string imageUrl);
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -22,31 +22,11 @@ namespace Doppler.PushContact.Services.Messages
 
         public async Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null, string imageUrl = null)
         {
-            if (string.IsNullOrEmpty(title))
-            {
-                throw new ArgumentException($"'{nameof(title)}' cannot be null or empty.", nameof(title));
-            }
-
-            if (string.IsNullOrEmpty(body))
-            {
-                throw new ArgumentException($"'{nameof(body)}' cannot be null or empty.", nameof(body));
-            }
+            ValidateMessage(title, body, onClickLink, imageUrl);
 
             if (targetDeviceTokens == null || !targetDeviceTokens.Any())
             {
                 throw new ArgumentException($"'{nameof(targetDeviceTokens)}' cannot be null or empty.", nameof(targetDeviceTokens));
-            }
-
-            if (!string.IsNullOrEmpty(onClickLink)
-                && (!Uri.TryCreate(onClickLink, UriKind.Absolute, out var onClickLinkResult) || onClickLinkResult.Scheme != Uri.UriSchemeHttps))
-            {
-                throw new ArgumentException($"'{nameof(onClickLink)}' must be an absolute URL with HTTPS scheme.", nameof(onClickLink));
-            }
-
-            if (!string.IsNullOrEmpty(imageUrl)
-                && (!Uri.TryCreate(imageUrl, UriKind.Absolute, out var imgUrlResult) || imgUrlResult.Scheme != Uri.UriSchemeHttps))
-            {
-                throw new ArgumentException($"'{nameof(imageUrl)}' must be an absolute URL with HTTPS scheme.", nameof(imageUrl));
             }
 
             // TODO: use adhock token here.
@@ -91,6 +71,31 @@ namespace Doppler.PushContact.Services.Messages
                     NotSuccessErrorDetails = !x.IsSuccess ? $"{nameof(x.Exception.MessagingErrorCode)} {x.Exception.MessagingErrorCode} - {nameof(x.Exception.Message)} {x.Exception.Message}" : null
                 })
             };
+        }
+
+        public void ValidateMessage(string title, string body, string onClickLink, string imageUrl)
+        {
+            if (string.IsNullOrEmpty(title))
+            {
+                throw new ArgumentException($"'{nameof(title)}' cannot be null or empty.", nameof(title));
+            }
+
+            if (string.IsNullOrEmpty(body))
+            {
+                throw new ArgumentException($"'{nameof(body)}' cannot be null or empty.", nameof(body));
+            }
+
+            if (!string.IsNullOrEmpty(onClickLink)
+                && (!Uri.TryCreate(onClickLink, UriKind.Absolute, out var onClickLinkResult) || onClickLinkResult.Scheme != Uri.UriSchemeHttps))
+            {
+                throw new ArgumentException($"'{nameof(onClickLink)}' must be an absolute URL with HTTPS scheme.", nameof(onClickLink));
+            }
+
+            if (!string.IsNullOrEmpty(imageUrl)
+                && (!Uri.TryCreate(imageUrl, UriKind.Absolute, out var imgUrlResult) || imgUrlResult.Scheme != Uri.UriSchemeHttps))
+            {
+                throw new ArgumentException($"'{nameof(imageUrl)}' must be an absolute URL with HTTPS scheme.", nameof(imageUrl));
+            }
         }
     }
 }


### PR DESCRIPTION
Add a new enpoint to create a message (and return the related messageId) => (**POST**) `/domains/{domain}/message`.

Treat errors related to the body content and return a "proper" _http status code_ and a related message:
![image](https://user-images.githubusercontent.com/1985175/195208483-30b0cc63-5251-4da1-83db-8ed28c3e554d.png)

@mmosquera and @Manu0912 what do you think about this error code: **[422 Unprocessable Entity](https://www.rfc-editor.org/rfc/rfc4918#section-11.2)**

(Maybe we can consider treat in similar way those errors when send a message by token or visitorguid).