### PR TITLE
[DOP-1314] - Add endpoint to get push contact enabled by visitorGuid

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -2875,5 +2875,32 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
+        [Theory]
+        [InlineData("exampleDomain", "exampleVisitorGuid")]
+        public async Task GetEnabledByVisitorGuid_should_return_ok_when_authorization_header_is_empty(string domain, string visitorGuid)
+        {
+            // Arrange
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var messageRepositoryMock = new Mock<IMessageRepository>();
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(pushContactServiceMock.Object);
+                    services.AddSingleton(messageRepositoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Get, $"push-contacts/{domain}/{visitorGuid}");
+
+            // Act
+            var response = await client.SendAsync(request);
+            _output.WriteLine(response.GetHeadersAsString());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
     }
 }

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -199,6 +199,26 @@ namespace Doppler.PushContact.Controllers
             return Ok(visitorGuidsList);
         }
 
+        [AllowAnonymous]
+        [HttpGet]
+        [Route("push-contacts/{domain}/{visitorGuid}")]
+        public async Task<IActionResult> GetEnabledByVisitorGuid([FromRoute] string domain, [FromRoute] string visitorGuid)
+        {
+            if (string.IsNullOrEmpty(domain) || string.IsNullOrWhiteSpace(domain))
+            {
+                return BadRequest($"'{nameof(domain)}' cannot be null, empty or whitespace.");
+            }
+
+            if (string.IsNullOrEmpty(visitorGuid) || string.IsNullOrWhiteSpace(visitorGuid))
+            {
+                return BadRequest($"'{nameof(visitorGuid)}' cannot be null, empty or whitespace.");
+            }
+
+            var hasPushNotificationEnabled = await _pushContactService.GetEnabledByVisitorGuid(domain, visitorGuid);
+
+            return Ok(hasPushNotificationEnabled);
+        }
+
         [HttpGet]
         [Route("push-contacts/messages/delivery-results")]
         public async Task<ActionResult<ApiPage<MessageDeliveryResult>>> GetMessages([FromQuery] int page, [FromQuery] int per_page, [FromQuery] DateTimeOffset from, [FromQuery] DateTimeOffset to)

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -32,5 +32,7 @@ namespace Doppler.PushContact.Services
         Task UpdatePushContactVisitorGuid(string deviceToken, string visitorGuid);
 
         Task<ApiPage<string>> GetAllVisitorGuidByDomain(string domain, int page, int per_page);
+
+        Task<bool> GetEnabledByVisitorGuid(string domain, string visitorGuid);
     }
 }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -565,6 +565,28 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
+        public async Task<bool> GetEnabledByVisitorGuid(string domain, string visitorGuid)
+        {
+            var filterBuilder = Builders<BsonDocument>.Filter;
+            var filter = filterBuilder.Eq(PushContactDocumentProps.DomainPropName, domain)
+                & filterBuilder.Eq(PushContactDocumentProps.VisitorGuidPropName, visitorGuid)
+                & filterBuilder.Eq(PushContactDocumentProps.DeletedPropName, false);
+
+            try
+            {
+                var pushContactsFiltered = await (await PushContacts.FindAsync(filter)).ToListAsync();
+
+                return pushContactsFiltered.Any();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Error getting active {nameof(PushContactModel)}s by {nameof(visitorGuid)} {visitorGuid}");
+
+                throw;
+            }
+
+        }
+
         private IMongoCollection<BsonDocument> PushContacts
         {
             get


### PR DESCRIPTION
## Summary
- Now we have an endpoint to know if a visitor guid has an active push contact

Ticket: [DOP-1314](https://makingsense.atlassian.net/jira/software/projects/DOP/boards/14?selectedIssue=DOP-1314)

[DOP-1314]: https://makingsense.atlassian.net/browse/DOP-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ