### PR TITLE
Dop 1522 improve getting message results

### DIFF
--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -175,8 +175,22 @@ namespace Doppler.PushContact.Controllers
         [Route("push-contacts/{domain}/messages/{messageId}/details")]
         public async Task<IActionResult> GetMessageDetails([FromRoute] string domain, [FromRoute] Guid messageId, [FromQuery][Required] DateTimeOffset from, [FromQuery][Required] DateTimeOffset to)
         {
-            var messageResult = await _pushContactService.GetDeliveredMessageSummarizationAsync(domain, messageId, from, to);
+            // obtain summarized result directly from message
+            var messagedetails = await _messageRepository.GetMessageDetailsAsync(domain, messageId);
+            if (messagedetails != null && messagedetails.Sent > 0)
+            {
+                return Ok(new
+                {
+                    messagedetails.Domain,
+                    MessageId = messageId,
+                    messagedetails.Sent,
+                    messagedetails.Delivered,
+                    messagedetails.NotDelivered
+                });
+            }
 
+            // summarize result from history_events
+            var messageResult = await _pushContactService.GetDeliveredMessageSummarizationAsync(domain, messageId, from, to);
             return Ok(new
             {
                 messageResult.Domain,

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -108,18 +108,28 @@ namespace Doppler.PushContact.Services.Messages
             {
                 BsonDocument message = await (await Messages.FindAsync<BsonDocument>(filter)).SingleOrDefaultAsync();
 
-                return new MessageDetails
+                var messageDetails = new MessageDetails
                 {
                     MessageId = message.GetValue(MessageDocumentProps.MessageIdPropName).AsGuid,
                     Domain = message.GetValue(MessageDocumentProps.DomainPropName).AsString,
                     Title = message.GetValue(MessageDocumentProps.TitlePropName).AsString,
                     Body = message.GetValue(MessageDocumentProps.BodyPropName).AsString,
-                    OnClickLinkPropName = message.GetValue(MessageDocumentProps.OnClickLinkPropName) == BsonNull.Value ? null : message.GetValue(MessageDocumentProps.OnClickLinkPropName).AsString,
                     Sent = message.GetValue(MessageDocumentProps.SentPropName).AsInt32,
                     Delivered = message.GetValue(MessageDocumentProps.DeliveredPropName).AsInt32,
                     NotDelivered = message.GetValue(MessageDocumentProps.NotDeliveredPropName).AsInt32,
-                    ImageUrl = message.GetValue(MessageDocumentProps.OnClickLinkPropName) == BsonNull.Value ? null : message.GetValue(MessageDocumentProps.ImageUrlPropName).AsString
                 };
+
+                if (message.TryGetValue(MessageDocumentProps.OnClickLinkPropName, out BsonValue onClickLinkValue))
+                {
+                    messageDetails.OnClickLinkPropName = onClickLinkValue == BsonNull.Value ? null : onClickLinkValue.AsString;
+                }
+
+                if (message.TryGetValue(MessageDocumentProps.ImageUrlPropName, out BsonValue imageUrlValue))
+                {
+                    messageDetails.ImageUrl = imageUrlValue == BsonNull.Value ? null : imageUrlValue.AsString;
+                }
+
+                return messageDetails;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Se mejoró el endpoint para obtener las estadisticas de un mensaje, para los reportes. 
Ahora los numeros se obtienen directamente desde el mensaje, si el mismo los tiene registrados, sino se seguirá sumarizando los `history_events` de `push_contacts`, como se hace actualmente.