### PR TITLE
Dop 1529 increment message stats sending an existent message

### DIFF
--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -1987,60 +1987,6 @@ namespace Doppler.PushContact.Test.Controllers
         }
 
         [Fact]
-        public async Task Message_By_Visitor_Guid_should_call_DeleteByDeviceTokenAsync_with_not_valid_target_device_tokens_returned_by_message_sender()
-        {
-            // Arrange
-            var fixture = new Fixture();
-
-            var pushContactServiceMock = new Mock<IPushContactService>();
-            var messageRepositoryMock = new Mock<IMessageRepository>();
-
-            var sendMessageResult = new SendMessageResult
-            {
-                SendMessageTargetResult = fixture.CreateMany<SendMessageTargetResult>(10)
-            };
-            sendMessageResult.SendMessageTargetResult.First().IsValidTargetDeviceToken = false;
-
-            var messageSenderMock = new Mock<IMessageSender>();
-            messageSenderMock
-                .Setup(x => x.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<string>(), It.IsAny<string>(), null))
-                .ReturnsAsync(sendMessageResult);
-
-            var client = _factory.WithWebHostBuilder(builder =>
-            {
-                builder.ConfigureTestServices(services =>
-                {
-                    services.AddSingleton(pushContactServiceMock.Object);
-                    services.AddSingleton(messageSenderMock.Object);
-                    services.AddSingleton(messageRepositoryMock.Object);
-                });
-            }).CreateClient(new WebApplicationFactoryClientOptions());
-
-            var domain = fixture.Create<string>();
-            var message = new Message
-            {
-                Title = fixture.Create<string>(),
-                Body = fixture.Create<string>(),
-                OnClickLink = fixture.Create<string>()
-            };
-            var visitorGuid = fixture.Create<string>();
-
-            var request = new HttpRequestMessage(HttpMethod.Post, $"push-contacts/{domain}/{visitorGuid}/message")
-            {
-                Headers = { { "Authorization", $"Bearer {TestApiUsersData.TOKEN_SUPERUSER_EXPIRE_20330518}" } },
-                Content = JsonContent.Create(message)
-            };
-
-            // Act
-            var response = await client.SendAsync(request);
-
-            // Assert
-            pushContactServiceMock
-                .Verify(x => x.DeleteByDeviceTokenAsync(
-                    It.Is<IEnumerable<string>>(y => y.All(z => sendMessageResult.SendMessageTargetResult.Any(w => w.TargetDeviceToken == z && !w.IsValidTargetDeviceToken)))), Times.Once());
-        }
-
-        [Fact]
         public async Task Message_By_Visitor_Guid_should_does_not_call_AddHistoryEventsAsync_when_message_sender_returned_a_empty_target_result_collection()
         {
             // Arrange

--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -2188,9 +2188,7 @@ namespace Doppler.PushContact.Test.Controllers
             var response = await client.SendAsync(request);
 
             // Assert
-            pushContactServiceMock
-                .Verify(x => x.AddHistoryEventsAsync(
-                It.Is<IEnumerable<PushContactHistoryEvent>>(x => sendMessageResult.SendMessageTargetResult.All(y => x.Any(z => z.DeviceToken == y.TargetDeviceToken)))), Times.Once());
+            pushContactServiceMock.Verify(x => x.AddHistoryEventsAsync(It.IsAny<Guid>(), sendMessageResult), Times.Once());
         }
 
         [Fact]

--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -955,7 +955,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             var sut = CreateSut();
             // Act
             // Assert
-            var result = await Assert.ThrowsAsync<ArgumentNullException>(() => sut.UpdatePushContactsAsync(messageId, null));
+            var result = await Assert.ThrowsAsync<ArgumentNullException>(() => sut.AddHistoryEventsAsync(messageId, null));
         }
 
         [Theory]

--- a/Doppler.PushContact/Controllers/MessageController.cs
+++ b/Doppler.PushContact/Controllers/MessageController.cs
@@ -42,7 +42,7 @@ namespace Doppler.PushContact.Controllers
             var message = await _messageRepository.GetMessageDetailsByMessageIdAsync(messageId);
             var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLinkPropName, message.ImageUrl);
 
-            await _pushContactService.UpdatePushContactsAsync(messageId, sendMessageResult);
+            await _pushContactService.AddHistoryEventsAsync(messageId, sendMessageResult);
 
             var sent = sendMessageResult.SendMessageTargetResult.Count();
             var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);

--- a/Doppler.PushContact/Controllers/MessageController.cs
+++ b/Doppler.PushContact/Controllers/MessageController.cs
@@ -44,6 +44,10 @@ namespace Doppler.PushContact.Controllers
 
             await _pushContactService.UpdatePushContactsAsync(messageId, sendMessageResult);
 
+            var sent = sendMessageResult.SendMessageTargetResult.Count();
+            var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);
+            await _messageRepository.IncrementMessageStats(messageId, sent, delivered, sent - delivered);
+
             return Ok(new MessageResult
             {
                 MessageId = messageId

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -104,7 +104,7 @@ namespace Doppler.PushContact.Controllers
 
                 var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl, pushApiToken);
 
-                await _pushContactService.UpdatePushContactsAsync(messageId, sendMessageResult);
+                await _pushContactService.AddHistoryEventsAsync(messageId, sendMessageResult);
 
                 var sent = sendMessageResult.SendMessageTargetResult.Count();
                 var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);
@@ -129,7 +129,7 @@ namespace Doppler.PushContact.Controllers
             var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl);
 
             var messageId = Guid.NewGuid();
-            await _pushContactService.UpdatePushContactsAsync(messageId, sendMessageResult);
+            await _pushContactService.AddHistoryEventsAsync(messageId, sendMessageResult);
 
             var sent = sendMessageResult.SendMessageTargetResult.Count();
             var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -128,37 +128,8 @@ namespace Doppler.PushContact.Controllers
 
             var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl);
 
-            var notValidTargetDeviceToken = sendMessageResult
-                .SendMessageTargetResult?
-                .Where(x => !x.IsValidTargetDeviceToken)
-                .Select(x => x.TargetDeviceToken);
-
-            if (notValidTargetDeviceToken != null && notValidTargetDeviceToken.Any())
-            {
-                await _pushContactService.DeleteByDeviceTokenAsync(notValidTargetDeviceToken);
-            }
-
-            var now = DateTime.UtcNow;
             var messageId = Guid.NewGuid();
-
-            var pushContactHistoryEvents = sendMessageResult
-                .SendMessageTargetResult?
-                    .Select(x =>
-                    {
-                        return new PushContactHistoryEvent
-                        {
-                            DeviceToken = x.TargetDeviceToken,
-                            SentSuccess = x.IsSuccess,
-                            EventDate = now,
-                            Details = x.NotSuccessErrorDetails,
-                            MessageId = messageId
-                        };
-                    });
-
-            if (pushContactHistoryEvents != null && pushContactHistoryEvents.Any())
-            {
-                await _pushContactService.AddHistoryEventsAsync(pushContactHistoryEvents);
-            }
+            await _pushContactService.UpdatePushContactsAsync(messageId, sendMessageResult);
 
             var sent = sendMessageResult.SendMessageTargetResult.Count();
             var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -19,7 +19,7 @@ namespace Doppler.PushContact.Services
 
         Task AddHistoryEventsAsync(IEnumerable<PushContactHistoryEvent> pushContactHistoryEvents);
 
-        Task UpdatePushContactsAsync(Guid messageId, SendMessageResult sendMessageResult);
+        Task AddHistoryEventsAsync(Guid messageId, SendMessageResult sendMessageResult);
 
         Task<IEnumerable<string>> GetAllDeviceTokensByDomainAsync(string domain);
 

--- a/Doppler.PushContact/Services/Messages/IMessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageRepository.cs
@@ -15,5 +15,7 @@ namespace Doppler.PushContact.Services.Messages
         Task<ApiPage<MessageDeliveryResult>> GetMessages(int page, int per_page, DateTimeOffset from, DateTimeOffset to);
 
         Task UpdateDeliveriesAsync(Guid messageId, int sent, int delivered, int notDelivered);
+
+        Task IncrementMessageStats(Guid messageId, int sent, int delivered, int notDelivered);
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -210,6 +210,28 @@ namespace Doppler.PushContact.Services.Messages
             }
         }
 
+        public async Task IncrementMessageStats(Guid messageId, int sent, int delivered, int notDelivered)
+        {
+            var filter = Builders<BsonDocument>
+                .Filter
+                .Eq(MessageDocumentProps.MessageIdPropName, new BsonBinaryData(messageId, GuidRepresentation.Standard));
+
+            var update = Builders<BsonDocument>.Update
+                .Inc(MessageDocumentProps.SentPropName, sent)
+                .Inc(MessageDocumentProps.DeliveredPropName, delivered)
+                .Inc(MessageDocumentProps.NotDeliveredPropName, notDelivered);
+
+            try
+            {
+                var result = await Messages.UpdateOneAsync(filter, update);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, @$"Error incrementing message stats for {nameof(messageId)} {messageId}");
+                throw;
+            }
+        }
+
         private IMongoCollection<BsonDocument> Messages
         {
             get

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -236,7 +236,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
-        public async Task UpdatePushContactsAsync(Guid messageId, SendMessageResult sendMessageResult)
+        public async Task AddHistoryEventsAsync(Guid messageId, SendMessageResult sendMessageResult)
         {
             //TO DO: implement abstraction
             if (sendMessageResult == null)


### PR DESCRIPTION
Se modificó el endpoint para envio de un mensaje existente, para que incremente las estadisticas de envio en el mensaje apropiadamente.

Ademas se refactorizo el endpoint para envio de un mensaje nuevo. Se reemplazo el comportamiento definido en el controller por el uso del metodo `AddHistoryEventsAsync` (antes llamado `UpdatePushContactsAsync`) definido en el `PushContactService`.