### PR TITLE
Dop 1579 add push contact queuingservice project

### DIFF
--- a/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
+++ b/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
+++ b/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
+++ b/Doppler.PushContact.QueuingService/Doppler.PushContact.QueuingService.csproj
@@ -6,4 +6,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="EasyNetQ" Version="7.8.0" />
+    <PackageReference Include="EasyNetQ.Serialization.SystemTextJson" Version="7.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/IMessageQueuePublisher.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/IMessageQueuePublisher.cs
@@ -1,0 +1,11 @@
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public interface IMessageQueuePublisher : IDisposable
+    {
+        Task PublishAsync<T>(
+            T message,
+            string queueName,
+            CancellationToken cancellationToken
+        ) where T : class;
+    }
+}

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/IMessageQueueSubscriber.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/IMessageQueueSubscriber.cs
@@ -1,0 +1,11 @@
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public interface IMessageQueueSubscriber : IDisposable
+    {
+        Task<IDisposable> SubscribeAsync<T>(
+            Func<T, Task> handler,
+            string? queueName = null,
+            CancellationToken cancellationToken = default
+            ) where T : class;
+    }
+}

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerSettings.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerSettings.cs
@@ -2,11 +2,10 @@ namespace Doppler.PushContact.QueuingService.MessageQueueBroker
 {
     public class MessageQueueBrokerSettings
     {
-
         public required string ConnectionString { get; set; }
 
         /// <summary>
-        /// Password for connect to MessageQueueSubscriber. 
+        /// Password for connect to MessageQueueSubscriber.
         /// If ConnectionString has defined password parameter, will be replaced with this value if it is not empty.
         /// </summary>
         public string? Password { get; set; }

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerSettings.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerSettings.cs
@@ -1,0 +1,14 @@
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public class MessageQueueBrokerSettings
+    {
+
+        public required string ConnectionString { get; set; }
+
+        /// <summary>
+        /// Password for connect to MessageQueueSubscriber. 
+        /// If ConnectionString has defined password parameter, will be replaced with this value if it is not empty.
+        /// </summary>
+        public string? Password { get; set; }
+    }
+}

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/RabbitMessageQueuePublisher.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/RabbitMessageQueuePublisher.cs
@@ -1,0 +1,56 @@
+using EasyNetQ.ConnectionString;
+using EasyNetQ;
+using Microsoft.Extensions.Options;
+using EasyNetQ.Topology;
+using EasyNetQ.DI;
+
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public class RabbitMessageQueuePublisher : IMessageQueuePublisher
+    {
+        private readonly IBus _bus;
+
+        public RabbitMessageQueuePublisher(IOptions<MessageQueueBrokerSettings> options)
+        {
+            var connectionConfiguration = new ConnectionStringParser().Parse(options.Value.ConnectionString);
+            if (!string.IsNullOrWhiteSpace(options.Value.Password))
+            {
+                connectionConfiguration.Password = options.Value.Password;
+            }
+
+            _bus = RabbitHutch.CreateBus(connectionConfiguration, registerServices =>
+            {
+                registerServices.Register<ISerializer, EasyNetQ.Serialization.SystemTextJson.SystemTextJsonSerializer>();
+            });
+        }
+
+        public async Task PublishAsync<T>(T message, string queueName, CancellationToken cancellationToken) where T : class
+        {
+            await _bus.Advanced.QueueDeclareAsync(queueName, cancellationToken);
+            await _bus.Advanced.PublishAsync(Exchange.Default, queueName, mandatory: true, new Message<T>(message), cancellationToken);
+        }
+
+        #region IDisposable
+
+        private bool isDisposed;
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+
+            if (disposing)
+            {
+                _bus.Dispose();
+            }
+
+            isDisposed = true;
+        }
+
+        #endregion
+    }
+}

--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/RabbitMessageQueueSubscriber.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/RabbitMessageQueueSubscriber.cs
@@ -1,0 +1,66 @@
+using EasyNetQ;
+using EasyNetQ.ConnectionString;
+using EasyNetQ.DI;
+using Microsoft.Extensions.Options;
+
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public class RabbitMessageQueueSubscriber : IMessageQueueSubscriber
+    {
+        private readonly IBus _bus;
+
+        public RabbitMessageQueueSubscriber(IOptions<MessageQueueBrokerSettings> options)
+        {
+            var connectionConfiguration = new ConnectionStringParser().Parse(options.Value.ConnectionString);
+            if (!string.IsNullOrWhiteSpace(options.Value.Password))
+            {
+                connectionConfiguration.Password = options.Value.Password;
+            }
+
+            _bus = RabbitHutch.CreateBus(connectionConfiguration, registerServices =>
+            {
+                registerServices.Register<ISerializer, EasyNetQ.Serialization.SystemTextJson.SystemTextJsonSerializer>();
+            });
+        }
+
+        /// <inheritdoc/>
+        public async Task<IDisposable> SubscribeAsync<T>(Func<T, Task> action, string? queueName = null, CancellationToken cancellationToken = default) where T : class
+        {
+            var queue = await _bus.Advanced.QueueDeclareAsync(queueName, cancellationToken);
+            return _bus.Advanced.Consume(queue, async (body, properties, info) =>
+            {
+                using var stream = new MemoryStream(body.ToArray());
+                using var reader = new StreamReader(stream);
+                var jsonMessage = await reader.ReadToEndAsync();
+                var message = System.Text.Json.JsonSerializer.Deserialize<T>(jsonMessage);
+                if (message != null)
+                {
+                    await action.Invoke(message);
+                }
+            });
+        }
+
+        #region IDisposable
+
+        private bool _isDisposed;
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_isDisposed) return;
+
+            if (disposing)
+            {
+                _bus.Dispose();
+            }
+
+            _isDisposed = true;
+        }
+
+        #endregion
+    }
+}

--- a/Doppler.PushContact.sln
+++ b/Doppler.PushContact.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34928.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Doppler.PushContact", "Doppler.PushContact\Doppler.PushContact.csproj", "{F7ECF2EB-1BA6-4C7A-9AB4-E0DCCF73FC51}"
 EndProject
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc Files", "Misc Files", 
 		docs\send-push-notification-from-doppler-by-domain.png = docs\send-push-notification-from-doppler-by-domain.png
 		verify-w-docker.sh = verify-w-docker.sh
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doppler.PushContact.QueuingService", "Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj", "{D7EB0F28-2D96-4F82-B22D-297828BBA830}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +62,18 @@ Global
 		{BF93AC59-A63E-4CA7-AE6C-DC68C78AF452}.Release|x64.Build.0 = Release|Any CPU
 		{BF93AC59-A63E-4CA7-AE6C-DC68C78AF452}.Release|x86.ActiveCfg = Release|Any CPU
 		{BF93AC59-A63E-4CA7-AE6C-DC68C78AF452}.Release|x86.Build.0 = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|x64.Build.0 = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x64.ActiveCfg = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x64.Build.0 = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
A project to handle publishing and subscribing to Rabbit queues was added.
According to reading about [Exchange Topics](https://www.rabbitmq.com/tutorials/tutorial-five-python), the Exchange type used for now is Default (`Exchange.Default`), because the `Topic` is not working as we imagined; using the `Topic` does not guarantee handling only one queue, quite the opposite.