### PR TITLE
Dop 1579 publish notification in queues

### DIFF
--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerExtensions.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Doppler.PushContact.QueuingService.MessageQueueBroker
+{
+    public static class MessageQueueBrokerExtensions
+    {
+        public static IServiceCollection AddMessageQueueBroker(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.Configure<MessageQueueBrokerSettings>(configuration.GetSection(nameof(MessageQueueBrokerSettings)));
+
+            services.AddSingleton<IMessageQueuePublisher, RabbitMessageQueuePublisher>();
+
+            return services;
+        }
+    }
+}

--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -254,5 +254,118 @@ namespace Doppler.PushContact.Test.Services.Messages
                 .WithVerb(HttpMethod.Post)
                 .Times(1);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task AddMessageAsync_should_throw_argument_exception_when_title_is_null_or_empty(string title)
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var body = fixture.Create<string>();
+
+            var sut = CreateSut();
+
+            // Act
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMessageAsync(domain, title, body, null, null));
+
+            // Assert
+            Assert.Contains($"'title' cannot be null or empty.", exception.Message);
+            Assert.Equal("title", exception.ParamName);
+
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task AddMessageAsync_should_throw_argument_exception_when_body_is_null_or_empty(string body)
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+
+            var sut = CreateSut();
+
+            // Act
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMessageAsync(domain, title, body, null, null));
+
+            // Assert
+            Assert.Contains($"'body' cannot be null or empty.", exception.Message);
+            Assert.Equal("body", exception.ParamName);
+
+        }
+
+        [Theory]
+        [InlineData("http://urlwithhttpschema.com")]
+        [InlineData("urlwithoutschema.com")]
+        [InlineData("//not/absolute/url")]
+        [InlineData("https:invalidurl.com")]
+        [InlineData("https://invalidurl.com<>")]
+        public async Task AddMessageAsync_should_throw_argument_exception_when_onClickLink_isnt_valid_url(string onClickLink)
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var imageUrl = "https://www.mydomain.com/myImage.jpg";
+
+            var sut = CreateSut();
+
+            // Act
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMessageAsync(domain, title, body, onClickLink, imageUrl));
+
+            // Assert
+            Assert.Contains($"'onClickLink' must be an absolute URL with HTTPS scheme.", exception.Message);
+            Assert.Equal("onClickLink", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData("http://urlwithhttpschema.com/random-resource.img")]
+        [InlineData("urlwithoutschema.com/random-resource.img")]
+        [InlineData("//not/absolute/url/random-resource.img")]
+        [InlineData("https:invalidurl.com/random-resource.img")]
+        [InlineData("https://invalidurl.com<>/random-resource.img")]
+        public async Task AddMessageAsync_should_throw_argument_exception_when_imageUrl_isnt_valid_url(string imageUrl)
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var onClickLink = "https://www.mydomain.com";
+
+            var sut = CreateSut();
+
+            // Act
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMessageAsync(domain, title, body, onClickLink, imageUrl));
+
+            // Assert
+            Assert.Contains($"'imageUrl' must be an absolute URL with HTTPS scheme.", exception.Message);
+            Assert.Equal("imageUrl", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task AddMessageAsync_should_return_a_valid_guid()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var onClickLink = "https://www.mydomain.com";
+            var imageUrl = "https://www.mydomain.com/myImage.jpg";
+
+            var sut = CreateSut();
+
+            // Act
+            var result = await sut.AddMessageAsync(domain, title, body, onClickLink, imageUrl);
+
+            // Assert
+            Assert.IsType<Guid>(result);
+            Assert.NotEqual(Guid.Empty, result);
+        }
     }
 }

--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -26,11 +26,15 @@ namespace Doppler.PushContact.Test.Services.Messages
 
         private static MessageSender CreateSut(
             IPushApiTokenGetter pushApiTokenGetter = null,
-            IOptions<MessageSenderSettings> messageSenderSettings = null)
+            IOptions<MessageSenderSettings> messageSenderSettings = null,
+            MessageRepository messageRepository = null
+        )
         {
             return new MessageSender(
                 messageSenderSettings ?? Options.Create(messageSenderSettingsDefault),
-                pushApiTokenGetter ?? Mock.Of<IPushApiTokenGetter>());
+                pushApiTokenGetter ?? Mock.Of<IPushApiTokenGetter>(),
+                messageRepository ?? Mock.Of<IMessageRepository>()
+            );
         }
 
         [Theory]

--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using Doppler.PushContact.Services;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Messages.ExternalContracts;
 using Flurl.Http;
@@ -27,13 +28,15 @@ namespace Doppler.PushContact.Test.Services.Messages
         private static MessageSender CreateSut(
             IPushApiTokenGetter pushApiTokenGetter = null,
             IOptions<MessageSenderSettings> messageSenderSettings = null,
-            MessageRepository messageRepository = null
+            IMessageRepository messageRepository = null,
+            IPushContactService pushContactService = null
         )
         {
             return new MessageSender(
                 messageSenderSettings ?? Options.Create(messageSenderSettingsDefault),
                 pushApiTokenGetter ?? Mock.Of<IPushApiTokenGetter>(),
-                messageRepository ?? Mock.Of<IMessageRepository>()
+                messageRepository ?? Mock.Of<IMessageRepository>(),
+                pushContactService ?? Mock.Of<IPushContactService>()
             );
         }
 

--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -1,4 +1,5 @@
 using AutoFixture;
+using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Models;
 using Doppler.PushContact.Services;
 using Microsoft.Extensions.Logging;
@@ -1491,6 +1492,137 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             Assert.True(result);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task GetAllSubscriptionInfoByDomainAsync_should_throw_argument_exception_when_domain_is_null_or_empty
+            (string domain)
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act
+            // Assert
+            var result = await Assert.ThrowsAsync<ArgumentException>(() => sut.GetAllSubscriptionInfoByDomainAsync(domain));
+        }
+
+        [Fact]
+        public async Task GetAllSubscriptionInfoByDomainAsync_should_throw_exception_and_log_error_when_subscriptionsinfo_cannot_be_getter_from_storage()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var pushMongoContextSettings = fixture.Create<PushMongoContextSettings>();
+
+            var domain = fixture.Create<string>();
+
+            var pushContactsCollectionMock = new Mock<IMongoCollection<BsonDocument>>();
+            pushContactsCollectionMock
+                .Setup(x => x.FindAsync(It.IsAny<FilterDefinition<BsonDocument>>(), It.IsAny<FindOptions<BsonDocument, BsonDocument>>(), default))
+                .ThrowsAsync(new Exception());
+
+            var mongoDatabaseMock = new Mock<IMongoDatabase>();
+            mongoDatabaseMock
+                .Setup(x => x.GetCollection<BsonDocument>(pushMongoContextSettings.PushContactsCollectionName, null))
+                .Returns(pushContactsCollectionMock.Object);
+
+            var mongoClientMock = new Mock<IMongoClient>();
+            mongoClientMock
+                .Setup(x => x.GetDatabase(pushMongoContextSettings.DatabaseName, null))
+                .Returns(mongoDatabaseMock.Object);
+
+            var loggerMock = new Mock<ILogger<PushContactService>>();
+
+            var sut = CreateSut(
+                mongoClientMock.Object,
+                Options.Create(pushMongoContextSettings),
+                logger: loggerMock.Object);
+
+            // Act
+            // Assert
+            await Assert.ThrowsAsync<Exception>(() => sut.GetAllSubscriptionInfoByDomainAsync(domain));
+
+            loggerMock.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString() == $"Error getting {nameof(SubscriptionInfoDTO)}s by {nameof(domain)} {domain}"),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAllSubscriptionInfoByDomainAsync_should_return_subscriptionsinfo_filtered_by_domain()
+        {
+            // Arrange
+            List<BsonDocument> allPushContactDocuments = FakePushContactDocuments(10);
+
+            var random = new Random();
+            int randomPushContactIndex = random.Next(allPushContactDocuments.Count);
+            var domainFilter = allPushContactDocuments[randomPushContactIndex][PushContactDocumentProps.DomainPropName].AsString;
+
+            var fixture = new Fixture();
+
+            var pushMongoContextSettings = fixture.Create<PushMongoContextSettings>();
+
+            var pushContactsCursorMock = new Mock<IAsyncCursor<BsonDocument>>();
+            pushContactsCursorMock
+                .Setup(_ => _.Current)
+                .Returns(allPushContactDocuments.Where(x => x[PushContactDocumentProps.DomainPropName].AsString == domainFilter));
+
+            pushContactsCursorMock
+                .SetupSequence(_ => _.MoveNext(It.IsAny<CancellationToken>()))
+                .Returns(true)
+                .Returns(false);
+
+            pushContactsCursorMock
+                .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(true))
+                .Returns(Task.FromResult(false));
+
+            var pushContactsCollectionMock = new Mock<IMongoCollection<BsonDocument>>();
+            pushContactsCollectionMock
+                .Setup(x => x.FindAsync(It.IsAny<FilterDefinition<BsonDocument>>(), It.IsAny<FindOptions<BsonDocument, BsonDocument>>(), default))
+                .ReturnsAsync(pushContactsCursorMock.Object);
+
+            var mongoDatabase = new Mock<IMongoDatabase>();
+            mongoDatabase
+                .Setup(x => x.GetCollection<BsonDocument>(pushMongoContextSettings.PushContactsCollectionName, null))
+                .Returns(pushContactsCollectionMock.Object);
+
+            var mongoClient = new Mock<IMongoClient>();
+            mongoClient
+                .Setup(x => x.GetDatabase(pushMongoContextSettings.DatabaseName, null))
+                .Returns(mongoDatabase.Object);
+
+            var sut = CreateSut(
+                mongoClient.Object,
+                Options.Create(pushMongoContextSettings));
+
+            // Act
+            var result = await sut.GetAllSubscriptionInfoByDomainAsync(domainFilter);
+
+            // Assert
+            Assert.All(result, res => allPushContactDocuments
+                    .Single(p => p[PushContactDocumentProps.DomainPropName].AsString == domainFilter &&
+                        p[PushContactDocumentProps.DeviceTokenPropName].AsString == res.DeviceToken &&
+                        p[PushContactDocumentProps.Subscription_PropName][PushContactDocumentProps.Subscription_EndPoint_PropName] == res.Subscription.EndPoint &&
+                        p[PushContactDocumentProps.Subscription_PropName][PushContactDocumentProps.Subscription_P256DH_PropName] == res.Subscription.Keys.P256DH &&
+                        p[PushContactDocumentProps.Subscription_PropName][PushContactDocumentProps.Subscription_Auth_PropName] == res.Subscription.Keys.Auth
+                    )
+                );
+        }
+        private static BsonDocument FakeSubscriptionDocument()
+        {
+            var fixture = new Fixture();
+            return new BsonDocument {
+                { PushContactDocumentProps.Subscription_EndPoint_PropName, fixture.Create<string>() },
+                { PushContactDocumentProps.Subscription_Auth_PropName, fixture.Create<string>() },
+                { PushContactDocumentProps.Subscription_P256DH_PropName, fixture.Create<string>() },
+            };
+        }
+
         private static List<BsonDocument> FakePushContactDocuments(int count)
         {
             var fixture = new Fixture();
@@ -1505,7 +1637,8 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
                             { PushContactDocumentProps.VisitorGuidPropName, fixture.Create<string>() },
                             { PushContactDocumentProps.EmailPropName, fixture.Create<string>() },
                             { PushContactDocumentProps.ModifiedPropName, fixture.Create<DateTime>().ToUniversalTime() },
-                            { PushContactDocumentProps.DeletedPropName, fixture.Create<bool>() }
+                            { PushContactDocumentProps.DeletedPropName, fixture.Create<bool>() },
+                            { PushContactDocumentProps.Subscription_PropName, FakeSubscriptionDocument() },
                     };
                 })
                 .ToList();

--- a/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
@@ -1,0 +1,390 @@
+using AutoFixture;
+using Doppler.PushContact.Controllers;
+using Doppler.PushContact.DTOs;
+using Doppler.PushContact.Models;
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
+using Doppler.PushContact.Services;
+using Doppler.PushContact.Services.Messages;
+using Doppler.PushContact.Services.Queue;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.PushContact.Test.Services
+{
+    public class TestQueueBackgroundService : QueueBackgroundService
+    {
+        public TestQueueBackgroundService(IBackgroundQueue backgroundQueue)
+            : base(backgroundQueue)
+        {
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // overwrite the method to do nothing on the tests
+            await Task.CompletedTask;
+        }
+    }
+
+    public class WebPushPublisherServiceTest
+    {
+        private static readonly WebPushQueueSettings webPushQueueSettingsDefault =
+            new WebPushQueueSettings
+            {
+                PushEndpointMappings = new Dictionary<string, List<string>>
+                {
+                    { "google", new List<string> { "https://fcm.googleapis.com" } },
+                    { "mozilla", new List<string> { "https://updates.push.services.mozilla.com" } },
+                    { "microsoft", new List<string> { "https://wns.windows.com" } },
+                    { "apple", new List<string> { "https://api.push.apple.com" } }
+                }
+            };
+
+        private const string QUEUE_NAME_SUFIX = "webpush.queue";
+        private const string DEFAULT_QUEUE_NAME = $"default.{QUEUE_NAME_SUFIX}";
+
+        private static WebPushPublisherService CreateSut(
+            IPushContactService pushContactService = null,
+            IBackgroundQueue backgroundQueue = null,
+            IMessageSender messageSender = null,
+            ILogger<WebPushPublisherService> logger = null,
+            IMessageQueuePublisher messageQueuePublisher = null,
+            IOptions<WebPushQueueSettings> webPushQueueSettings = null
+        )
+        {
+            return new WebPushPublisherService(
+                pushContactService ?? Mock.Of<IPushContactService>(),
+                backgroundQueue ?? Mock.Of<IBackgroundQueue>(),
+                messageSender ?? Mock.Of<IMessageSender>(),
+                logger ?? Mock.Of<ILogger<WebPushPublisherService>>(),
+                messageQueuePublisher ?? Mock.Of<IMessageQueuePublisher>(),
+                webPushQueueSettings ?? Options.Create(webPushQueueSettingsDefault)
+            );
+        }
+
+        [Theory]
+        [InlineData("https://unknown.service.api.com", DEFAULT_QUEUE_NAME)]
+        [InlineData("https://fcm.googleapis.com/path", $"google.{QUEUE_NAME_SUFIX}")]
+        [InlineData("https://updates.push.services.mozilla.com", $"mozilla.{QUEUE_NAME_SUFIX}")]
+        [InlineData("https://wns.windows.com", $"microsoft.{QUEUE_NAME_SUFIX}")]
+        [InlineData("https://api.push.apple.com", $"apple.{QUEUE_NAME_SUFIX}")]
+        public async Task ProcessWebPush_should_finish_ok_pushing_subscriptions_in_proper_queue_and_calling_SendFirebase_but_without_items(
+            string endpoint,
+            string expectedQueueName
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var subscriptions = new List<SubscriptionInfoDTO>
+            {
+                new SubscriptionInfoDTO
+                {
+                    Subscription = new SubscriptionModel
+                    {
+                        EndPoint = endpoint,
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = "auth",
+                            P256DH = "p256dh"
+                        }
+                    }
+                },
+            };
+
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .ReturnsAsync(subscriptions);
+
+            var messageSenderMock = new Mock<IMessageSender>();
+            var messageQueuePublisherMock = new Mock<IMessageQueuePublisher>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                messageSender: messageSenderMock.Object,
+                messageQueuePublisher: messageQueuePublisherMock.Object
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            messageQueuePublisherMock.Verify(
+                q => q.PublishAsync(
+                    It.Is<WebPushDTO>(dto => dto.MessageId == messageId),
+                    expectedQueueName,
+                    CancellationToken.None
+                ),
+                Times.Once
+            );
+
+            // verify calling to SendFirebaseWebPushAsync but passing an empty list
+            messageSenderMock.Verify(
+                s => s.SendFirebaseWebPushAsync(
+                    It.Is<WebPushDTO>(dto => dto.MessageId == messageId),
+                    It.Is<List<string>>(x => x.Count == 0),
+                    null),
+                Times.Once
+            );
+        }
+
+        [Theory]
+        [InlineData(null, "auth", "p256dh")]
+        [InlineData("", "auth", "p256dh")]
+        [InlineData("endpoint", null, "p256dh")]
+        [InlineData("endpoint", "", "p256dh")]
+        [InlineData("endpoint", "auth", null)]
+        [InlineData("endpoint", "auth", "")]
+        public async Task ProcessWebPush_should_finish_ok_calling_SendFirebase_with_items_and_no_considering_wrong_subscriptions(
+            string endpoint,
+            string auth,
+            string p256dh
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var subscriptions = new List<SubscriptionInfoDTO>
+            {
+                new SubscriptionInfoDTO
+                {
+                    Subscription = new SubscriptionModel
+                    {
+                        EndPoint = endpoint,
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = auth,
+                            P256DH = p256dh
+                        }
+                    },
+                    DeviceToken = "deviceToken"
+                },
+            };
+
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .ReturnsAsync(subscriptions);
+
+            var messageSenderMock = new Mock<IMessageSender>();
+            var messageQueuePublisherMock = new Mock<IMessageQueuePublisher>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                messageSender: messageSenderMock.Object,
+                messageQueuePublisher: messageQueuePublisherMock.Object
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            messageQueuePublisherMock.Verify(
+                q => q.PublishAsync(
+                    It.IsAny<WebPushDTO>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+                Times.Never
+            );
+
+            // verify calling to SendFirebaseWebPushAsync passing a list with a item
+            messageSenderMock.Verify(
+                s => s.SendFirebaseWebPushAsync(
+                    It.Is<WebPushDTO>(dto => dto.MessageId == messageId),
+                    It.Is<List<string>>(x => x.Count == 1),
+                    null),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public async Task ProcessWebPush_should_catch_and_log_unexpected_exception()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .Throws(new Exception());
+
+            var loggerMock = new Mock<ILogger<WebPushPublisherService>>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                logger: loggerMock.Object
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            loggerMock.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"An unexpected error occurred processing webpush for domain: {domain}")),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessWebPush_should_invoke_to_internal_EnqueueWebPushAsync_and_it_should_catch_and_log_unexpected_exception()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var subscriptions = new List<SubscriptionInfoDTO>
+            {
+                new SubscriptionInfoDTO
+                {
+                    Subscription = new SubscriptionModel
+                    {
+                        EndPoint = "endpoint",
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = "auth",
+                            P256DH = "p256dh"
+                        }
+                    }
+                },
+            };
+
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .ReturnsAsync(subscriptions);
+
+            var messageQueuePublisherMock = new Mock<IMessageQueuePublisher>();
+            messageQueuePublisherMock
+                .Setup(mqp => mqp.PublishAsync(It.IsAny<DopplerWebPushDTO>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            var loggerMock = new Mock<ILogger<WebPushPublisherService>>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                messageQueuePublisher: messageQueuePublisherMock.Object,
+                logger: loggerMock.Object
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            loggerMock.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"An unexpected error occurred enqueuing webpush for messageId: {webPushDTO.MessageId}")),
+                    It.IsAny<Exception>(),
+                    It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
+                Times.Once);
+        }
+    }
+}

--- a/Doppler.PushContact.sln
+++ b/Doppler.PushContact.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc Files", "Misc Files", 
 		.prettierignore = .prettierignore
 		docs\add-new-push-contact-sd.png = docs\add-new-push-contact-sd.png
 		api-contracts.http = api-contracts.http
+		backing-services-stack.yml = backing-services-stack.yml
 		build-n-publish.sh = build-n-publish.sh
 		demo.http = demo.http
 		Dockerfile = Dockerfile

--- a/Doppler.PushContact/DTOs/DopplerWebPushDTO.cs
+++ b/Doppler.PushContact/DTOs/DopplerWebPushDTO.cs
@@ -1,0 +1,9 @@
+using Doppler.PushContact.Models;
+
+namespace Doppler.PushContact.DTOs
+{
+    public class DopplerWebPushDTO : WebPushDTO
+    {
+        public SubscriptionModel Subscription { get; set; }
+    }
+}

--- a/Doppler.PushContact/DTOs/SubscriptionInfoDTO.cs
+++ b/Doppler.PushContact/DTOs/SubscriptionInfoDTO.cs
@@ -1,0 +1,10 @@
+using Doppler.PushContact.Models;
+
+namespace Doppler.PushContact.DTOs
+{
+    public class SubscriptionInfoDTO
+    {
+        public string DeviceToken { get; set; }
+        public SubscriptionModel Subscription { get; set; }
+    }
+}

--- a/Doppler.PushContact/DTOs/WebPushDTO.cs
+++ b/Doppler.PushContact/DTOs/WebPushDTO.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Doppler.PushContact.DTOs
+{
+    public class WebPushDTO
+    {
+        public string Title { get; set; }
+
+        public string Body { get; set; }
+
+        public string OnClickLink { get; set; }
+
+        public string ImageUrl { get; set; }
+
+        public Guid MessageId { get; set; }
+    }
+}

--- a/Doppler.PushContact/Doppler.PushContact.csproj
+++ b/Doppler.PushContact/Doppler.PushContact.csproj
@@ -20,4 +20,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -1,4 +1,5 @@
 using Doppler.PushContact.ApiModels;
+using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Models;
 using Doppler.PushContact.Services.Messages;
 using System;
@@ -24,6 +25,8 @@ namespace Doppler.PushContact.Services
         Task AddHistoryEventsAsync(Guid messageId, SendMessageResult sendMessageResult);
 
         Task<IEnumerable<string>> GetAllDeviceTokensByDomainAsync(string domain);
+
+        Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByDomainAsync(string domain);
 
         Task<IEnumerable<string>> GetAllDeviceTokensByVisitorGuidAsync(string visitorGuid);
 

--- a/Doppler.PushContact/Services/IWebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/IWebPushPublisherService.cs
@@ -1,0 +1,8 @@
+using Doppler.PushContact.DTOs;
+namespace Doppler.PushContact.Services
+{
+    public interface IWebPushPublisherService
+    {
+        void ProcessWebPush(string domain, WebPushDTO webPushDTO, string authenticationApiToken = null);
+    }
+}

--- a/Doppler.PushContact/Services/Messages/IMessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageSender.cs
@@ -1,3 +1,4 @@
+using Doppler.PushContact.DTOs;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,5 +10,6 @@ namespace Doppler.PushContact.Services.Messages
         Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null, string imageUrl = null, string pushApiToken = null);
         void ValidateMessage(string title, string body, string onClickLink, string imageUrl);
         Task<Guid> AddMessageAsync(string domain, string title, string body, string onClickLink, string imageUrl);
+        Task SendFirebaseWebPushAsync(WebPushDTO webPushDTO, List<string> deviceTokens, string authenticationApiToken);
     }
 }

--- a/Doppler.PushContact/Services/Messages/IMessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageSender.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,7 +7,7 @@ namespace Doppler.PushContact.Services.Messages
     public interface IMessageSender
     {
         Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null, string imageUrl = null, string pushApiToken = null);
-
         void ValidateMessage(string title, string body, string onClickLink, string imageUrl);
+        Task<Guid> AddMessageAsync(string domain, string title, string body, string onClickLink, string imageUrl);
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -123,7 +123,7 @@ namespace Doppler.PushContact.Services.Messages
 
         public async Task SendFirebaseWebPushAsync(WebPushDTO webPushDTO, List<string> deviceTokens, string authenticationApiToken)
         {
-            if (!deviceTokens.Any())
+            if (deviceTokens == null || !deviceTokens.Any())
             {
                 return;
             }

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -1,3 +1,4 @@
+using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Services.Messages.ExternalContracts;
 using Flurl;
 using Flurl.Http;
@@ -14,15 +15,19 @@ namespace Doppler.PushContact.Services.Messages
         private readonly MessageSenderSettings _messageSenderSettings;
         private readonly IPushApiTokenGetter _pushApiTokenGetter;
         private readonly IMessageRepository _messageRepository;
+        private readonly IPushContactService _pushContactService;
 
         public MessageSender(
             IOptions<MessageSenderSettings> messageSenderSettings,
             IPushApiTokenGetter pushApiTokenGetter,
-            IMessageRepository messageRepository)
+            IMessageRepository messageRepository,
+            IPushContactService pushContactService
+        )
         {
             _messageSenderSettings = messageSenderSettings.Value;
             _pushApiTokenGetter = pushApiTokenGetter;
             _messageRepository = messageRepository;
+            _pushContactService = pushContactService;
         }
 
         public async Task<SendMessageResult> SendAsync(string title, string body, IEnumerable<string> targetDeviceTokens, string onClickLink = null, string imageUrl = null, string pushApiToken = null)
@@ -114,6 +119,36 @@ namespace Doppler.PushContact.Services.Messages
             {
                 throw new ArgumentException($"'{nameof(imageUrl)}' must be an absolute URL with HTTPS scheme.", nameof(imageUrl));
             }
+        }
+
+        public async Task SendFirebaseWebPushAsync(WebPushDTO webPushDTO, List<string> deviceTokens, string authenticationApiToken)
+        {
+            if (!deviceTokens.Any())
+            {
+                return;
+            }
+
+            var sendMessageResult = await SendAsync(
+                webPushDTO.Title,
+                webPushDTO.Body,
+                deviceTokens,
+                webPushDTO.OnClickLink,
+                webPushDTO.ImageUrl,
+                authenticationApiToken
+            );
+
+            await RegisterStatisticsAsync(webPushDTO.MessageId, sendMessageResult);
+        }
+
+        private async Task RegisterStatisticsAsync(Guid messageId, SendMessageResult sendMessageResult)
+        {
+            await _pushContactService.AddHistoryEventsAsync(messageId, sendMessageResult);
+
+            var sent = sendMessageResult.SendMessageTargetResult.Count();
+            var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);
+            var notDelivered = sent - delivered;
+
+            await _messageRepository.UpdateDeliveriesAsync(messageId, sent, delivered, notDelivered);
         }
     }
 }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -383,7 +383,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
-        public List<SubscriptionInfoDTO> GetSubscriptionsInfoFromBsonDocuments(List<BsonDocument> pushContacts)
+        private List<SubscriptionInfoDTO> GetSubscriptionsInfoFromBsonDocuments(List<BsonDocument> pushContacts)
         {
             return pushContacts.Select(x =>
             {

--- a/Doppler.PushContact/Services/PushServicesExtensions.cs
+++ b/Doppler.PushContact/Services/PushServicesExtensions.cs
@@ -1,3 +1,4 @@
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,6 +15,8 @@ namespace Doppler.PushContact.Services
             services.AddScoped<IPushContactService, PushContactService>();
 
             services.AddScoped<IDomainService, DomainService>();
+
+            services.Configure<WebPushQueueSettings>(configuration.GetSection(nameof(WebPushQueueSettings)));
 
             return services;
         }

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -19,15 +19,18 @@ namespace Doppler.PushContact.Services
         private readonly IPushContactService _pushContactService;
         private readonly IBackgroundQueue _backgroundQueue;
         private readonly IMessageSender _messageSender;
-        private readonly ILogger<MessageController> _logger;
+        private readonly ILogger<WebPushPublisherService> _logger;
         private readonly IMessageQueuePublisher _messageQueuePublisher;
         private readonly Dictionary<string, List<string>> _pushEndpointMappings;
+
+        private const string QUEUE_NAME_SUFIX = "webpush.queue";
+        private const string DEFAULT_QUEUE_NAME = $"default.{QUEUE_NAME_SUFIX}";
 
         public WebPushPublisherService(
             IPushContactService pushContactService,
             IBackgroundQueue backgroundQueue,
             IMessageSender messageSender,
-            ILogger<MessageController> logger,
+            ILogger<WebPushPublisherService> logger,
             IMessageQueuePublisher messageQueuePublisher,
             IOptions<WebPushQueueSettings> webPushQueueSettings
         )
@@ -115,12 +118,12 @@ namespace Doppler.PushContact.Services
                 {
                     if (endpoint.StartsWith(url, StringComparison.OrdinalIgnoreCase))
                     {
-                        return $"{mapping.Key}.webpush.queue";
+                        return $"{mapping.Key}.{QUEUE_NAME_SUFIX}";
                     }
                 }
             }
 
-            return "default.webpush.queue";
+            return DEFAULT_QUEUE_NAME;
         }
     }
 }

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -1,0 +1,70 @@
+using Doppler.PushContact.Controllers;
+using Doppler.PushContact.DTOs;
+using Doppler.PushContact.Services.Messages;
+using Doppler.PushContact.Services.Queue;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.Services
+{
+    public class WebPushPublisherService : IWebPushPublisherService
+    {
+        private readonly IPushContactService _pushContactService;
+        private readonly IBackgroundQueue _backgroundQueue;
+        private readonly IMessageSender _messageSender;
+        private readonly ILogger<MessageController> _logger;
+
+        public WebPushPublisherService(
+            IPushContactService pushContactService,
+            IBackgroundQueue backgroundQueue,
+            IMessageSender messageSender,
+            ILogger<MessageController> logger
+        )
+        {
+            _pushContactService = pushContactService;
+            _backgroundQueue = backgroundQueue;
+            _messageSender = messageSender;
+            _logger = logger;
+        }
+
+        public void ProcessWebPush(string domain, WebPushDTO messageDTO, string authenticationApiToken = null)
+        {
+            _backgroundQueue.QueueBackgroundQueueItem(async (cancellationToken) =>
+            {
+                try
+                {
+                    var deviceTokens = new List<string>();
+                    var subscriptionsInfo = await _pushContactService.GetAllSubscriptionInfoByDomainAsync(domain);
+                    foreach (var subscription in subscriptionsInfo)
+                    {
+                        if (subscription.Subscription != null &&
+                            subscription.Subscription.Keys != null &&
+                            !string.IsNullOrEmpty(subscription.Subscription.EndPoint) &&
+                            !string.IsNullOrEmpty(subscription.Subscription.Keys.Auth) &&
+                            !string.IsNullOrEmpty(subscription.Subscription.Keys.P256DH)
+                        )
+                        {
+                            // TODO: enqueue webpush to send with Doppler service
+                        }
+                        else if (!string.IsNullOrEmpty(subscription.DeviceToken))
+                        {
+                            deviceTokens.Add(subscription.DeviceToken);
+                        }
+                    }
+
+                    await _messageSender.SendFirebaseWebPushAsync(messageDTO, deviceTokens, authenticationApiToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "An unexpected error occurred enqueing/sending webpush for domain: {domain} and messageId: {messageId}.",
+                        domain,
+                        messageDTO.MessageId
+                    );
+                }
+            });
+        }
+    }
+}

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -1,4 +1,3 @@
-using Doppler.PushContact.Controllers;
 using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Models;
 using Doppler.PushContact.QueuingService.MessageQueueBroker;

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -1,10 +1,15 @@
 using Doppler.PushContact.Controllers;
 using Doppler.PushContact.DTOs;
+using Doppler.PushContact.Models;
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Queue;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Doppler.PushContact.Services
 {
@@ -14,18 +19,21 @@ namespace Doppler.PushContact.Services
         private readonly IBackgroundQueue _backgroundQueue;
         private readonly IMessageSender _messageSender;
         private readonly ILogger<MessageController> _logger;
+        private readonly IMessageQueuePublisher _messageQueuePublisher;
 
         public WebPushPublisherService(
             IPushContactService pushContactService,
             IBackgroundQueue backgroundQueue,
             IMessageSender messageSender,
-            ILogger<MessageController> logger
+            ILogger<MessageController> logger,
+            IMessageQueuePublisher messageQueuePublisher
         )
         {
             _pushContactService = pushContactService;
             _backgroundQueue = backgroundQueue;
             _messageSender = messageSender;
             _logger = logger;
+            _messageQueuePublisher = messageQueuePublisher;
         }
 
         public void ProcessWebPush(string domain, WebPushDTO messageDTO, string authenticationApiToken = null)
@@ -45,7 +53,7 @@ namespace Doppler.PushContact.Services
                             !string.IsNullOrEmpty(subscription.Subscription.Keys.P256DH)
                         )
                         {
-                            // TODO: enqueue webpush to send with Doppler service
+                            await EnqueueWebPushAsync(messageDTO, subscription.Subscription, cancellationToken);
                         }
                         else if (!string.IsNullOrEmpty(subscription.DeviceToken))
                         {
@@ -59,12 +67,67 @@ namespace Doppler.PushContact.Services
                 {
                     _logger.LogError(
                         ex,
-                        "An unexpected error occurred enqueing/sending webpush for domain: {domain} and messageId: {messageId}.",
+                        "An unexpected error occurred processing webpush for domain: {domain} and messageId: {messageId}.",
                         domain,
                         messageDTO.MessageId
                     );
                 }
             });
+        }
+
+        private async Task EnqueueWebPushAsync(WebPushDTO messageDTO, SubscriptionModel subscription, CancellationToken cancellationToken)
+        {
+            var webPushMessage = new DopplerWebPushDTO()
+            {
+                Title = messageDTO.Title,
+                Body = messageDTO.Body,
+                OnClickLink = messageDTO.OnClickLink,
+                ImageUrl = messageDTO.ImageUrl,
+                Subscription = subscription,
+                MessageId = messageDTO.MessageId,
+            };
+
+            string queueName = GetQueueName(subscription.EndPoint);
+
+            try
+            {
+                await _messageQueuePublisher.PublishAsync(webPushMessage, queueName, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "An unexpected error occurred enqueuing webpush for messageId: {messageId} and subscription: {subscription}.",
+                    messageDTO.MessageId,
+                    JsonSerializer.Serialize(subscription, new JsonSerializerOptions { WriteIndented = true })
+                );
+            }
+        }
+
+        // TODO: obtains queue names and endpoints for each service from config
+        private string GetQueueName(string endpoint)
+        {
+            if (endpoint.StartsWith("https://fcm.googleapis.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return "google.notification.queue";
+            }
+
+            if (endpoint.StartsWith("https://updates.push.services.mozilla.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return "mozilla.notification.queue";
+            }
+
+            if (endpoint.StartsWith("https://wns.windows.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return "microsoft.notification.queue";
+            }
+
+            if (endpoint.StartsWith("https://api.push.apple.com", StringComparison.OrdinalIgnoreCase))
+            {
+                return "apple.notification.queue";
+            }
+
+            return "default.notification.queue";
         }
     }
 }

--- a/Doppler.PushContact/Services/WebPushQueueSettings.cs
+++ b/Doppler.PushContact/Services/WebPushQueueSettings.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.Services
+{
+    public class WebPushQueueSettings
+    {
+        public Dictionary<string, List<string>> PushEndpointMappings { get; set; }
+    }
+}

--- a/Doppler.PushContact/Startup.cs
+++ b/Doppler.PushContact/Startup.cs
@@ -36,6 +36,7 @@ namespace Doppler.PushContact
             services.AddScoped<IPushApiTokenGetter, PushApiTokenGetter>();
             services.AddPushServices(Configuration);
             services.AddMessageSender(Configuration);
+            services.AddScoped<IWebPushPublisherService, WebPushPublisherService>();
             services.AddScoped<IMessageRepository, MessageRepository>();
             services.AddSingleton<IBackgroundQueue, BackgroundQueue>();
             services.AddHostedService<QueueBackgroundService>();

--- a/Doppler.PushContact/Startup.cs
+++ b/Doppler.PushContact/Startup.cs
@@ -1,20 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Doppler.PushContact.DopplerSecurity;
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.Services;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Queue;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
-using MongoDB.Driver;
+using System;
 
 namespace Doppler.PushContact
 {
@@ -36,6 +31,7 @@ namespace Doppler.PushContact
             services.AddScoped<IPushApiTokenGetter, PushApiTokenGetter>();
             services.AddPushServices(Configuration);
             services.AddMessageSender(Configuration);
+            services.AddMessageQueueBroker(Configuration);
             services.AddScoped<IWebPushPublisherService, WebPushPublisherService>();
             services.AddScoped<IMessageRepository, MessageRepository>();
             services.AddSingleton<IBackgroundQueue, BackgroundQueue>();

--- a/Doppler.PushContact/appsettings.Development.json
+++ b/Doppler.PushContact/appsettings.Development.json
@@ -10,5 +10,9 @@
   },
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys-dev"
+  },
+  "MessageQueueBrokerSettings": {
+    "ConnectionString": "host=localhost;username=guest;password=guest",
+    "Password": "guest"
   }
 }

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -35,5 +35,13 @@
   "MessageQueueBrokerSettings": {
     "ConnectionString": "REPLACE_WITH_RABBITMQ_CONNECTIONSTRING",
     "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
+  },
+  "WebPushQueueSettings": {
+    "PushEndpointMappings": {
+      "google": ["https://fcm.googleapis.com"],
+      "mozilla": ["https://updates.push.services.mozilla.com"],
+      "microsoft": ["https://wns.windows.com"],
+      "apple": ["https://api.push.apple.com"]
+    }
   }
 }

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -31,5 +31,9 @@
     "PushApiUrl": "REPLACE_WITH_PUSH_API_URL",
     "FatalMessagingErrorCodes": [1, 6],
     "PushTokensLimit": 400
+  },
+  "MessageQueueBrokerSettings": {
+    "ConnectionString": "REPLACE_WITH_RABBITMQ_CONNECTIONSTRING",
+    "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
   }
 }

--- a/README.md
+++ b/README.md
@@ -114,3 +114,24 @@ Doppler->>+DopplerUser: Automation report
 # MongoDB ER diagram
 
 ![diagrama ER mongodb push notifications](https://user-images.githubusercontent.com/57307782/176199725-dc81a9aa-4ff6-4a14-beb1-dac2ebe9aa17.png)
+
+# To run the backend services
+
+1. **Run the `backing-services-stack.yml` file**:
+   To start up the services defined in `backing-services-stack.yml` file, use the following command:
+
+   ```sh
+   docker-compose -f backing-services-stack.yml up
+   ```
+
+   If you want them to run in the background (detached mode), add the `-d` option:
+
+   ```sh
+   docker-compose -f backing-services-stack.yml up -d
+   ```
+
+2. **Stop the services**:
+   To stop and remove the services use the following command:
+   ```sh
+   docker-compose -f backing-services-stack.yml down
+   ```

--- a/backing-services-stack.yml
+++ b/backing-services-stack.yml
@@ -1,0 +1,6 @@
+services:
+  rabbitmq:
+    image: rabbitmq:management
+    ports:
+      - 5672:5672
+      - 15672:15672


### PR DESCRIPTION
A new endpoint to enqueue firebase notifications by domain was added: `message/domains/{domain}`.
When this endpoint is called, all device tokens for this domain, obtained from the DB, will be enqueued to send the proper notifications.

**Note**: review commit by commit to understanding changes in a better way.

**UPDATE!!!** the changes discussed with @mmosquera have been added. When it is identified that the contact has a `subscription` (to be used sending with Doppler), the message to be sent is enqueued. If there is no `subscription` but there is a **Firebase** `deviceToken`, the message will be sent immediately using **Firebase**."

An example enqueueing messages in the local environment:
![image](https://github.com/FromDoppler/doppler-push-contact/assets/1985175/d7d07ca2-2f1f-4178-85ad-36ce3b426420)
