### PR TITLE
Dop 1579 add queues consumer

### DIFF
--- a/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerExtensions.cs
+++ b/Doppler.PushContact.QueuingService/MessageQueueBroker/MessageQueueBrokerExtensions.cs
@@ -10,6 +10,7 @@ namespace Doppler.PushContact.QueuingService.MessageQueueBroker
             services.Configure<MessageQueueBrokerSettings>(configuration.GetSection(nameof(MessageQueueBrokerSettings)));
 
             services.AddSingleton<IMessageQueuePublisher, RabbitMessageQueuePublisher>();
+            services.AddSingleton<IMessageQueueSubscriber, RabbitMessageQueueSubscriber>();
 
             return services;
         }

--- a/Doppler.PushContact.WebPushSender/DTOs/DopplerWebPushDTO.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/DopplerWebPushDTO.cs
@@ -1,0 +1,7 @@
+namespace Doppler.PushContact.WebPushSender.DTOs
+{
+    public class DopplerWebPushDTO : WebPushDTO
+    {
+        public SubscriptionDTO Subscription { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/SubscriptionDTO.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/SubscriptionDTO.cs
@@ -1,0 +1,16 @@
+namespace Doppler.PushContact.WebPushSender.DTOs
+{
+    public class SubscriptionKeysDTO
+    {
+        public string P256DH { get; set; }
+
+        public string Auth { get; set; }
+    }
+
+    public class SubscriptionDTO
+    {
+        public string EndPoint { get; set; }
+
+        public SubscriptionKeysDTO Keys { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponse.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Doppler.PushContact.WebPushSender.DTOs.WebPushApi
+{
+    public class SendMessageResponse
+    {
+        public List<SendMessageResponseDetail> Responses { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponseDetail.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponseDetail.cs
@@ -1,0 +1,9 @@
+namespace Doppler.PushContact.WebPushSender.DTOs.WebPushApi
+{
+    public class SendMessageResponseDetail
+    {
+        public bool IsSuccess { get; set; }
+        public SendMessageResponseException Exception { get; set; }
+        public SubscriptionResponse Subscription { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponseException.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SendMessageResponseException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Doppler.PushContact.WebPushSender.DTOs.WebPushApi
+{
+    public class SendMessageResponseException
+    {
+        public int MessagingErrorCode { get; set; }
+        public string Message { get; set; }
+        public TimeSpan? RetryAfterSeconds { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SubscriptionResponse.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushApi/SubscriptionResponse.cs
@@ -1,0 +1,9 @@
+namespace Doppler.PushContact.WebPushSender.DTOs.WebPushApi
+{
+    public class SubscriptionResponse
+    {
+        public string Endpoint { get; set; }
+        public string P256DH { get; set; }
+        public string Auth { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushDTO.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushDTO.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Doppler.PushContact.WebPushSender.DTOs
+{
+    public class WebPushDTO
+    {
+        public string Title { get; set; }
+
+        public string Body { get; set; }
+
+        public string OnClickLink { get; set; }
+
+        public string ImageUrl { get; set; }
+
+        public Guid MessageId { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/DTOs/WebPushProcessingResult.cs
+++ b/Doppler.PushContact.WebPushSender/DTOs/WebPushProcessingResult.cs
@@ -1,0 +1,10 @@
+namespace Doppler.PushContact.WebPushSender.DTOs
+{
+    public class WebPushProcessingResult
+    {
+        public bool SuccessfullyDelivered { get; set; }
+        public bool LimitsExceeded { get; set; }
+        public bool InvalidSubscription { get; set; }
+        public bool FailedProcessing { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
+++ b/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
+++ b/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
+++ b/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
+++ b/Doppler.PushContact.WebPushSender/Doppler.PushContact.WebPushSender.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Doppler.PushContact.WebPushSender/Logging/LogglySetup.cs
+++ b/Doppler.PushContact.WebPushSender/Logging/LogglySetup.cs
@@ -1,0 +1,32 @@
+using Loggly.Config;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Doppler.PushContact.WebPushSender.Logging
+{
+    public static class LogglySetup
+    {
+        private const string DefaultEndpointHostname = "logs-01.loggly.com";
+        private const int DefaultEndpointPort = 443;
+
+        public static IConfiguration ConfigureLoggly(
+            this IConfiguration configuration,
+            IHostEnvironment hostingEnvironment,
+            string appSettingsSection = nameof(LogglyConfig))
+        {
+            var config = LogglyConfig.Instance;
+
+            // Set default values
+            config.Transport.EndpointPort = DefaultEndpointPort;
+
+            // Bind values from configuration
+            configuration.GetSection(appSettingsSection).Bind(config);
+
+            // Configure convention values if not set in configuration
+            config.ApplicationName ??= hostingEnvironment.ApplicationName;
+            config.Transport.EndpointHostname ??= DefaultEndpointHostname;
+
+            return configuration;
+        }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Logging/SerilogSetup.cs
+++ b/Doppler.PushContact.WebPushSender/Logging/SerilogSetup.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using System;
+
+namespace Doppler.PushContact.WebPushSender.Logging
+{
+    public static class SerilogSetup
+    {
+        public static LoggerConfiguration SetupSeriLog(
+            this LoggerConfiguration loggerConfiguration,
+            IConfiguration configuration,
+            IHostEnvironment hostEnvironment)
+        {
+            configuration.ConfigureLoggly(hostEnvironment);
+
+            loggerConfiguration
+                .WriteTo.Console()
+                .Enrich.WithProperty("Application", hostEnvironment.ApplicationName)
+                .Enrich.WithProperty("Environment", hostEnvironment.EnvironmentName)
+                .Enrich.WithProperty("Platform", Environment.OSVersion.Platform)
+                .Enrich.WithProperty("OSVersion", Environment.OSVersion)
+                .Enrich.FromLogContext();
+
+            if (!hostEnvironment.IsDevelopment())
+            {
+                loggerConfiguration
+                    .WriteTo.Loggly();
+            }
+
+            loggerConfiguration.ReadFrom.Configuration(configuration);
+
+            return loggerConfiguration;
+        }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Doppler.PushContact.WebPushSender
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = CreateHostBuilder(args).Build();
+            host.Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((hostContext, configurationBuilder) =>
+                {
+                    // It is if you want to override the configuration in your
+                    // local environment, `*.Secret.*` files will not be included in git.
+                    configurationBuilder.AddJsonFile("appsettings.Secret.json", true);
+
+                    // It is to override configuration using Docker's services.
+                    // Probably this will be the way of overriding the configuration in our Swarm stack.
+                    configurationBuilder.AddJsonFile("/run/secrets/appsettings.Secret.json", true);
+
+                    configurationBuilder.AddEnvironmentVariables();
+                })
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddHostedService<SenderExecutor>();
+                });
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -1,4 +1,6 @@
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.WebPushSender.Logging;
+using Doppler.PushContact.WebPushSender.Senders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -34,6 +36,12 @@ namespace Doppler.PushContact.WebPushSender
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
+                    var configuration = hostContext.Configuration;
+                    services.AddMessageQueueBroker(configuration);
+
+                    // Register IWebPushSender's
+                    services.AddSingleton<IWebPushSender, DefaultWebPushSender>();
+
                     services.AddHostedService<SenderExecutor>();
                 });
     }

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -39,6 +39,8 @@ namespace Doppler.PushContact.WebPushSender
                     var configuration = hostContext.Configuration;
                     services.AddMessageQueueBroker(configuration);
 
+                    services.Configure<WebPushSenderSettings>(configuration.GetSection(nameof(WebPushSenderSettings)));
+
                     // Register IWebPushSender's
                     services.AddSingleton<IWebPushSender, DefaultWebPushSender>();
 

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -1,6 +1,8 @@
+using Doppler.PushContact.WebPushSender.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog;
 
 namespace Doppler.PushContact.WebPushSender
 {
@@ -14,6 +16,10 @@ namespace Doppler.PushContact.WebPushSender
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .UseSerilog((hostContext, loggerConfiguration) =>
+                {
+                    loggerConfiguration.SetupSeriLog(hostContext.Configuration, hostContext.HostingEnvironment);
+                })
                 .ConfigureAppConfiguration((hostContext, configurationBuilder) =>
                 {
                     // It is if you want to override the configuration in your

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -4,7 +4,9 @@ using Doppler.PushContact.WebPushSender.Senders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Serilog;
+using System;
 
 namespace Doppler.PushContact.WebPushSender
 {
@@ -39,7 +41,12 @@ namespace Doppler.PushContact.WebPushSender
                     var configuration = hostContext.Configuration;
                     services.AddMessageQueueBroker(configuration);
 
-                    services.Configure<WebPushSenderSettings>(configuration.GetSection(nameof(WebPushSenderSettings)));
+                    services
+                        .Configure<WebPushSenderSettings>(configuration.GetSection(nameof(WebPushSenderSettings)))
+                        .Configure<IOptions<WebPushSenderSettings>>(
+                            options => options.Value.Type = Enum.Parse<WebPushSenderTypes>(
+                                configuration.GetSection(nameof(WebPushSenderSettings)).GetSection("Type").Value, true)
+                            );
 
                     // Register IWebPushSender's
                     services.AddSingleton<IWebPushSender, DefaultWebPushSender>();

--- a/Doppler.PushContact.WebPushSender/Program.cs
+++ b/Doppler.PushContact.WebPushSender/Program.cs
@@ -48,6 +48,8 @@ namespace Doppler.PushContact.WebPushSender
                                 configuration.GetSection(nameof(WebPushSenderSettings)).GetSection("Type").Value, true)
                             );
 
+                    services.AddSingleton<IWebPushSenderFactory, WebPushSenderFactory>();
+
                     // Register IWebPushSender's
                     services.AddSingleton<IWebPushSender, DefaultWebPushSender>();
 

--- a/Doppler.PushContact.WebPushSender/SenderExecutor.cs
+++ b/Doppler.PushContact.WebPushSender/SenderExecutor.cs
@@ -1,6 +1,7 @@
 using Doppler.PushContact.WebPushSender.Senders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,9 +13,13 @@ namespace Doppler.PushContact.WebPushSender
         private readonly IWebPushSender _webPushSender;
         private readonly ILogger<SenderExecutor> _logger;
 
-        public SenderExecutor(IWebPushSender webPushSender, ILogger<SenderExecutor> logger)
+        public SenderExecutor(
+            IWebPushSenderFactory webPushSenderFactory,
+            IOptions<WebPushSenderSettings> webPushSenderSettings,
+            ILogger<SenderExecutor> logger
+        )
         {
-            _webPushSender = webPushSender;
+            _webPushSender = webPushSenderFactory.CreateSender(webPushSenderSettings);
             _logger = logger;
         }
 

--- a/Doppler.PushContact.WebPushSender/SenderExecutor.cs
+++ b/Doppler.PushContact.WebPushSender/SenderExecutor.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.Hosting;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender
+{
+    public class SenderExecutor : BackgroundService
+    {
+        public SenderExecutor()
+        {
+        }
+
+        public override async Task StartAsync(CancellationToken cancellationToken)
+        {
+            // TODO: initialize queues
+            await base.StartAsync(cancellationToken);
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await base.StopAsync(cancellationToken);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                // TODO: define the delay time in the appsettings file
+                await Task.Delay(1000);
+            }
+        }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -2,6 +2,7 @@ using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.WebPushSender.DTOs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace Doppler.PushContact.WebPushSender.Senders
@@ -23,9 +24,17 @@ namespace Doppler.PushContact.WebPushSender.Senders
                 "Processing message in \"{QueueName}\":\n\tEndpoint: {EndPoint}",
                 _queueName,
                 message.Subscription.EndPoint
-                );
+            );
 
-            await SendWebPush(message);
+            WebPushProcessingResult processingResult = await SendWebPush(message);
+
+            _logger.LogDebug(
+                "Message processed:\n\tEndpoint: {EndPoint}\n\tResult: {WebPushProcessingResult}",
+                message.Subscription.EndPoint,
+                JsonConvert.SerializeObject(processingResult)
+            );
+
+            // TODO: analyze processingResult and take proper actions (register in db, retry, etc)
         }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -1,15 +1,19 @@
 using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.WebPushSender.DTOs;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
 
 namespace Doppler.PushContact.WebPushSender.Senders
 {
     public class DefaultWebPushSender : WebPushSenderBase
     {
-        // TODO: obtain queueName from config file
-        public DefaultWebPushSender(IMessageQueueSubscriber messageQueueConsumer, ILogger<DefaultWebPushSender> logger)
-            : base("default.webpush.queue", messageQueueConsumer, logger)
+        public DefaultWebPushSender(
+            IOptions<WebPushSenderSettings> webPushSenderSettings,
+            IMessageQueueSubscriber messageQueueConsumer,
+            ILogger<DefaultWebPushSender> logger
+        )
+            : base(webPushSenderSettings, messageQueueConsumer, logger)
         {
         }
 
@@ -17,9 +21,11 @@ namespace Doppler.PushContact.WebPushSender.Senders
         {
             // TODO: consider specific implementation
             _logger.LogInformation(
-                "Process message in 'Default' queue:\n\tEndpoint: {EndPoint}\n\tMessageId: {MessageId}",
+                "Process message in \"{queueName}\":\n\tEndpoint: {EndPoint}\n\tMessageId: {MessageId}",
+                _queueName,
                 message.Subscription.EndPoint,
-                message.MessageId);
+                message.MessageId
+                );
             await Task.Delay(2000);
         }
     }

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -1,0 +1,26 @@
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
+using Doppler.PushContact.WebPushSender.DTOs;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public class DefaultWebPushSender : WebPushSenderBase
+    {
+        // TODO: obtain queueName from config file
+        public DefaultWebPushSender(IMessageQueueSubscriber messageQueueConsumer, ILogger<DefaultWebPushSender> logger)
+            : base("default.webpush.queue", messageQueueConsumer, logger)
+        {
+        }
+
+        public override async Task HandleMessageAsync(DopplerWebPushDTO message)
+        {
+            // TODO: consider specific implementation
+            _logger.LogInformation(
+                "Process message in 'Default' queue:\n\tEndpoint: {EndPoint}\n\tMessageId: {MessageId}",
+                message.Subscription.EndPoint,
+                message.MessageId);
+            await Task.Delay(2000);
+        }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -10,10 +10,10 @@ namespace Doppler.PushContact.WebPushSender.Senders
     {
         public DefaultWebPushSender(
             IOptions<WebPushSenderSettings> webPushSenderSettings,
-            IMessageQueueSubscriber messageQueueConsumer,
+            IMessageQueueSubscriber messageQueueSubscriber,
             ILogger<DefaultWebPushSender> logger
         )
-            : base(webPushSenderSettings, messageQueueConsumer, logger)
+            : base(webPushSenderSettings, messageQueueSubscriber, logger)
         {
         }
 

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -19,14 +19,13 @@ namespace Doppler.PushContact.WebPushSender.Senders
 
         public override async Task HandleMessageAsync(DopplerWebPushDTO message)
         {
-            // TODO: consider specific implementation
-            _logger.LogInformation(
-                "Process message in \"{queueName}\":\n\tEndpoint: {EndPoint}\n\tMessageId: {MessageId}",
+            _logger.LogDebug(
+                "Processing message in \"{QueueName}\":\n\tEndpoint: {EndPoint}",
                 _queueName,
-                message.Subscription.EndPoint,
-                message.MessageId
+                message.Subscription.EndPoint
                 );
-            await Task.Delay(2000);
+
+            await SendWebPush(message);
         }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/IWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/IWebPushSender.cs
@@ -1,0 +1,13 @@
+using Doppler.PushContact.WebPushSender.DTOs;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public interface IWebPushSender
+    {
+        Task StartListeningAsync(CancellationToken cancellationToken);
+        void StopListeningAsync();
+        Task HandleMessageAsync(DopplerWebPushDTO message);
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Senders/IWebPushSenderFactory.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/IWebPushSenderFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Options;
+
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public interface IWebPushSenderFactory
+    {
+        IWebPushSender CreateSender(IOptions<WebPushSenderSettings> webPushSenderSettings);
+    }
+
+}

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
@@ -1,0 +1,43 @@
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
+using Doppler.PushContact.WebPushSender.DTOs;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public abstract class WebPushSenderBase : IWebPushSender
+    {
+        private readonly IMessageQueueSubscriber _messageQueueSubscriber;
+        protected readonly ILogger _logger;
+        private readonly string _queueName;
+        private IDisposable _queueSubscription;
+
+        protected WebPushSenderBase(string queueName, IMessageQueueSubscriber messageQueueConsumer, ILogger logger)
+        {
+            _messageQueueSubscriber = messageQueueConsumer;
+            _logger = logger;
+            _queueName = queueName;
+        }
+
+        public async Task StartListeningAsync(CancellationToken cancellationToken)
+        {
+            _queueSubscription = await _messageQueueSubscriber.SubscribeAsync<DopplerWebPushDTO>(
+                HandleMessageAsync,
+                _queueName,
+                cancellationToken
+            );
+        }
+
+        public void StopListeningAsync()
+        {
+            if (_queueSubscription != null)
+            {
+                _queueSubscription.Dispose();
+            }
+        }
+
+        public abstract Task HandleMessageAsync(DopplerWebPushDTO message);
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
@@ -17,11 +17,11 @@ namespace Doppler.PushContact.WebPushSender.Senders
 
         protected WebPushSenderBase(
             IOptions<WebPushSenderSettings> webPushSenderSettings,
-            IMessageQueueSubscriber messageQueueConsumer,
+            IMessageQueueSubscriber messageQueueSubscriber,
             ILogger logger
         )
         {
-            _messageQueueSubscriber = messageQueueConsumer;
+            _messageQueueSubscriber = messageQueueSubscriber;
             _logger = logger;
             _queueName = webPushSenderSettings.Value.QueueName;
         }

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
@@ -1,6 +1,7 @@
 using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.WebPushSender.DTOs;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,14 +12,18 @@ namespace Doppler.PushContact.WebPushSender.Senders
     {
         private readonly IMessageQueueSubscriber _messageQueueSubscriber;
         protected readonly ILogger _logger;
-        private readonly string _queueName;
+        protected readonly string _queueName;
         private IDisposable _queueSubscription;
 
-        protected WebPushSenderBase(string queueName, IMessageQueueSubscriber messageQueueConsumer, ILogger logger)
+        protected WebPushSenderBase(
+            IOptions<WebPushSenderSettings> webPushSenderSettings,
+            IMessageQueueSubscriber messageQueueConsumer,
+            ILogger logger
+        )
         {
             _messageQueueSubscriber = messageQueueConsumer;
             _logger = logger;
-            _queueName = queueName;
+            _queueName = webPushSenderSettings.Value.QueueName;
         }
 
         public async Task StartListeningAsync(CancellationToken cancellationToken)

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
@@ -16,10 +16,13 @@ namespace Doppler.PushContact.WebPushSender.Senders
 {
     public abstract class WebPushSenderBase : IWebPushSender
     {
+        private const string PUSHAPI_SENDWEBPUSH_PATH = "webpush";
+
         private readonly IMessageQueueSubscriber _messageQueueSubscriber;
         protected readonly ILogger _logger;
         protected readonly string _queueName;
         private IDisposable _queueSubscription;
+        private readonly string _pushApiUrl;
 
         protected WebPushSenderBase(
             IOptions<WebPushSenderSettings> webPushSenderSettings,
@@ -30,6 +33,7 @@ namespace Doppler.PushContact.WebPushSender.Senders
             _messageQueueSubscriber = messageQueueSubscriber;
             _logger = logger;
             _queueName = webPushSenderSettings.Value.QueueName;
+            _pushApiUrl = webPushSenderSettings.Value.PushApiUrl;
         }
 
         public async Task StartListeningAsync(CancellationToken cancellationToken)
@@ -53,14 +57,11 @@ namespace Doppler.PushContact.WebPushSender.Senders
 
         protected async Task<WebPushProcessingResult> SendWebPush(DopplerWebPushDTO message)
         {
-            // TODO: add value in appsettings file
-            var pushApiUrl = "https://apisint.fromdoppler.net/doppler-push";
-
             SendMessageResponse sendMessageResponse = null;
             try
             {
-                sendMessageResponse = await pushApiUrl
-                .AppendPathSegment("webpush")
+                sendMessageResponse = await _pushApiUrl
+                .AppendPathSegment(PUSHAPI_SENDWEBPUSH_PATH)
                 // TODO: analyze options to handle (or remove) push api token
                 //.WithOAuthBearerToken(pushApiToken)
                 .PostJsonAsync(new

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderFactory.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderFactory.cs
@@ -1,0 +1,39 @@
+using Doppler.PushContact.QueuingService.MessageQueueBroker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public class WebPushSenderFactory : IWebPushSenderFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public WebPushSenderFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public IWebPushSender CreateSender(IOptions<WebPushSenderSettings> webPushSenderSettings)
+        {
+            var messageQueueSubscriber = _serviceProvider.GetRequiredService<IMessageQueueSubscriber>();
+            var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
+
+            return webPushSenderSettings.Value.Type switch
+            {
+                WebPushSenderTypes.Default => new DefaultWebPushSender(
+                    webPushSenderSettings,
+                    messageQueueSubscriber,
+                    loggerFactory.CreateLogger<DefaultWebPushSender>()
+                ),
+                _ => new DefaultWebPushSender(
+                    webPushSenderSettings,
+                    messageQueueSubscriber,
+                    loggerFactory.CreateLogger<DefaultWebPushSender>()
+                ),
+            };
+        }
+    }
+
+}

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
@@ -1,0 +1,7 @@
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public class WebPushSenderSettings
+    {
+        public string QueueName { get; set; }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
@@ -3,5 +3,6 @@ namespace Doppler.PushContact.WebPushSender.Senders
     public class WebPushSenderSettings
     {
         public string QueueName { get; set; }
+        public WebPushSenderTypes Type { get; set; }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderSettings.cs
@@ -4,5 +4,6 @@ namespace Doppler.PushContact.WebPushSender.Senders
     {
         public string QueueName { get; set; }
         public WebPushSenderTypes Type { get; set; }
+        public string PushApiUrl { get; set; }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderTypes.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderTypes.cs
@@ -1,0 +1,11 @@
+namespace Doppler.PushContact.WebPushSender.Senders
+{
+    public enum WebPushSenderTypes
+    {
+        Default,
+        Apple,
+        Google,
+        Mozilla,
+        Windows
+    }
+}

--- a/Doppler.PushContact.WebPushSender/appsettings.Development.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/Doppler.PushContact.WebPushSender/appsettings.Development.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.Development.json
@@ -7,5 +7,9 @@
         "Microsoft.Hosting.Lifetime": "Information"
       }
     }
+  },
+  "MessageQueueBrokerSettings": {
+    "ConnectionString": "host=localhost;username=guest;password=guest",
+    "Password": "guest"
   }
 }

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -16,6 +16,7 @@
     "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
   },
   "WebPushSenderSettings": {
+    "Type": "default",
     "QueueName": "default.webpush.queue"
   }
 }

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -10,5 +10,9 @@
         "Microsoft.Hosting.Lifetime": "Information"
       }
     }
+  },
+  "MessageQueueBrokerSettings": {
+    "ConnectionString": "REPLACE_WITH_RABBITMQ_CONNECTIONSTRING",
+    "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
   }
 }

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "LogglyConfig": {
+    "CustomerToken": "REPLACE_WITH_CUSTOMER_TOKEN"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
+  }
+}

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -17,6 +17,7 @@
   },
   "WebPushSenderSettings": {
     "Type": "default",
-    "QueueName": "default.webpush.queue"
+    "QueueName": "default.webpush.queue",
+    "PushApiUrl": "REPLACE_WITH_PUSH_API_URL"
   }
 }

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -14,5 +14,8 @@
   "MessageQueueBrokerSettings": {
     "ConnectionString": "REPLACE_WITH_RABBITMQ_CONNECTIONSTRING",
     "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
+  },
+  "WebPushSenderSettings": {
+    "QueueName": "default.webpush.queue"
   }
 }

--- a/Doppler.PushContact.sln
+++ b/Doppler.PushContact.sln
@@ -27,7 +27,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc Files", "Misc Files", 
 		verify-w-docker.sh = verify-w-docker.sh
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doppler.PushContact.QueuingService", "Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj", "{D7EB0F28-2D96-4F82-B22D-297828BBA830}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Doppler.PushContact.QueuingService", "Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj", "{D7EB0F28-2D96-4F82-B22D-297828BBA830}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doppler.PushContact.WebPushSender", "Doppler.PushContact.WebPushSender\Doppler.PushContact.WebPushSender.csproj", "{DE7A0903-F180-442C-A456-4595BF87A6DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +77,18 @@ Global
 		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x64.Build.0 = Release|Any CPU
 		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x86.ActiveCfg = Release|Any CPU
 		{D7EB0F28-2D96-4F82-B22D-297828BBA830}.Release|x86.Build.0 = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|x64.Build.0 = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE7A0903-F180-442C-A456-4595BF87A6DE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add a new project to implement a background service that creates a `WebPushSender` according to a specific configuration.  This sender subscribes to a Rabbit queue (according to a configuration too) and sends a web push using the Doppler Push API.

**TODO**:
- analyze options to handle (or remove) push API token
- analyze delivery results and take proper actions (register in db, retry, etc)
- add unit tests

**IMPORTANT**: review it commit by commit to understanding better.