### PR TITLE
Dop 1598 add clicked n received events support to enqueue n send webpush

### DIFF
--- a/Doppler.PushContact.Models/DTOs/DopplerWebPushDTO.cs
+++ b/Doppler.PushContact.Models/DTOs/DopplerWebPushDTO.cs
@@ -4,5 +4,7 @@ namespace Doppler.PushContact.Models.DTOs
     {
         public SubscriptionDTO Subscription { get; set; }
         public string PushContactId { get; set; }
+        public string ClickedEventEndpoint { get; set; }
+        public string ReceivedEventEndpoint { get; set; }
     }
 }

--- a/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
@@ -33,8 +33,8 @@ namespace Doppler.PushContact.Test.Services
 
     public class WebPushPublisherServiceTest
     {
-        private static readonly WebPushQueueSettings webPushQueueSettingsDefault =
-            new WebPushQueueSettings
+        private static readonly WebPushPublisherSettings webPushQueueSettingsDefault =
+            new WebPushPublisherSettings
             {
                 PushEndpointMappings = new Dictionary<string, List<string>>
                 {
@@ -54,7 +54,7 @@ namespace Doppler.PushContact.Test.Services
             IMessageSender messageSender = null,
             ILogger<WebPushPublisherService> logger = null,
             IMessageQueuePublisher messageQueuePublisher = null,
-            IOptions<WebPushQueueSettings> webPushQueueSettings = null
+            IOptions<WebPushPublisherSettings> webPushQueueSettings = null
         )
         {
             return new WebPushPublisherService(

--- a/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
@@ -1,11 +1,11 @@
 using AutoFixture;
 using Doppler.PushContact.DTOs;
-using Doppler.PushContact.Models;
 using Doppler.PushContact.Models.DTOs;
 using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.Services;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Queue;
+using Doppler.PushContact.Transversal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -33,6 +33,13 @@ namespace Doppler.PushContact.Test.Services
 
     public class WebPushPublisherServiceTest
     {
+        public WebPushPublisherServiceTest()
+        {
+            var TestKey = "5Rz2VJbnjbhPfEKn3Ryd0E+u7jzOT2KCBicmM5wUq5Y=";
+            var TestIV = "7yZ8kT8L7UeO8JpH3Ir6jQ==";
+            EncryptionHelper.Initialize(TestKey, TestIV);
+        }
+
         private static readonly WebPushPublisherSettings webPushQueueSettingsDefault =
             new WebPushPublisherSettings
             {

--- a/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
@@ -392,5 +392,206 @@ namespace Doppler.PushContact.Test.Services
                     It.Is<Func<It.IsAnyType, Exception, string>>((v, t) => true)),
                 Times.Once);
         }
+
+        [Fact]
+        public async Task ProcessWebPush_should_finish_ok_pushing_a_subscription_with_defined_clicked_n_received_endpoints()
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+
+            var subscriptionEndpoint = "https://example.com/endpoint";
+            var queueNamePrefix = "example";
+
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var subscriptions = new List<SubscriptionInfoDTO>
+            {
+                new SubscriptionInfoDTO
+                {
+                    Subscription = new SubscriptionDTO
+                    {
+                        EndPoint = subscriptionEndpoint,
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = "auth",
+                            P256DH = "p256dh"
+                        }
+                    },
+                    PushContactId = "aContactId",
+                }
+            };
+
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .ReturnsAsync(subscriptions);
+
+            var webPushQueueSettings = new WebPushPublisherSettings
+            {
+                PushEndpointMappings = new Dictionary<string, List<string>>
+                {
+                    { queueNamePrefix, new List<string> { subscriptionEndpoint } }
+                },
+                PushApiUrl = "https://push.api.test",
+                ClickedEventEndpointPath = "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",
+                ReceivedEventEndpointPath = "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/received"
+            };
+
+            var messageQueuePublisherMock = new Mock<IMessageQueuePublisher>();
+            var messageSenderMock = new Mock<IMessageSender>();
+            var loggerMock = new Mock<ILogger<WebPushPublisherService>>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                messageSender: messageSenderMock.Object,
+                messageQueuePublisher: messageQueuePublisherMock.Object,
+                logger: loggerMock.Object,
+                webPushQueueSettings: Options.Create(webPushQueueSettings)
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            messageQueuePublisherMock.Verify(
+                q => q.PublishAsync(
+                    It.Is<DopplerWebPushDTO>(dto => dto.MessageId == messageId && dto.ClickedEventEndpoint != null && dto.ReceivedEventEndpoint != null),
+                    It.Is<string>(queue => queue == $"{queueNamePrefix}.webpush.queue"),
+                    It.IsAny<CancellationToken>()
+                ),
+                Times.Once
+            );
+        }
+
+        [Theory]
+        [InlineData(null, "[pushApiUrl]/clicked", "[pushApiUrl]/received", "aContactId")]
+        [InlineData("", "[pushApiUrl]/clicked", "[pushApiUrl]/received", "aContactId")]
+        [InlineData("aPushApiUrl", null, "[pushApiUrl]/received", "aContactId")]
+        [InlineData("aPushApiUrl", "", "[pushApiUrl]/received", "aContactId")]
+        [InlineData("aPushApiUrl", "[pushApiUrl]/clicked", null, "aContactId")]
+        [InlineData("aPushApiUrl", "[pushApiUrl]/clicked", "", "aContactId")]
+        [InlineData("aPushApiUrl", "[pushApiUrl]/clicked", "[pushApiUrl]/received", null)]
+        [InlineData("aPushApiUrl", "[pushApiUrl]/clicked", "[pushApiUrl]/received", "")]
+        public async Task ProcessWebPush_should_finish_ok_pushing_a_subscription_with_undefined_clicked_n_received_endpoints(
+            string pushApiUrl,
+            string clickedEventEndpoint,
+            string receivedEventEndpoint,
+            string contactId
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+
+            var domain = fixture.Create<string>();
+            var title = fixture.Create<string>();
+            var body = fixture.Create<string>();
+            var messageId = fixture.Create<Guid>();
+
+            var subscriptionEndpoint = "https://example.com/endpoint";
+            var queueNamePrefix = "example";
+
+            var webPushDTO = new WebPushDTO()
+            {
+                Title = title,
+                Body = body,
+                MessageId = messageId
+            };
+
+            var backgroundQueueMock = new Mock<IBackgroundQueue>();
+            Func<CancellationToken, Task> capturedFunctionToBeSimulated = null;
+
+            backgroundQueueMock
+                .Setup(q => q.QueueBackgroundQueueItem(It.IsAny<Func<CancellationToken, Task>>()))
+                .Callback<Func<CancellationToken, Task>>(func => capturedFunctionToBeSimulated = func);
+
+            var pushContactServiceMock = new Mock<IPushContactService>();
+            var subscriptions = new List<SubscriptionInfoDTO>
+            {
+                new SubscriptionInfoDTO
+                {
+                    Subscription = new SubscriptionDTO
+                    {
+                        EndPoint = subscriptionEndpoint,
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = "auth",
+                            P256DH = "p256dh"
+                        }
+                    },
+                    PushContactId = contactId,
+                }
+            };
+
+            pushContactServiceMock
+                .Setup(s => s.GetAllSubscriptionInfoByDomainAsync(domain))
+                .ReturnsAsync(subscriptions);
+
+            var webPushQueueSettings = new WebPushPublisherSettings
+            {
+                PushEndpointMappings = new Dictionary<string, List<string>>
+                {
+                    { queueNamePrefix, new List<string> { subscriptionEndpoint } }
+                },
+                PushApiUrl = pushApiUrl,
+                ClickedEventEndpointPath = clickedEventEndpoint,
+                ReceivedEventEndpointPath = receivedEventEndpoint,
+            };
+
+            var messageQueuePublisherMock = new Mock<IMessageQueuePublisher>();
+            var messageSenderMock = new Mock<IMessageSender>();
+            var loggerMock = new Mock<ILogger<WebPushPublisherService>>();
+
+            var sut = CreateSut(
+                pushContactService: pushContactServiceMock.Object,
+                backgroundQueue: backgroundQueueMock.Object,
+                messageSender: messageSenderMock.Object,
+                messageQueuePublisher: messageQueuePublisherMock.Object,
+                logger: loggerMock.Object,
+                webPushQueueSettings: Options.Create(webPushQueueSettings)
+            );
+
+            // Act
+            sut.ProcessWebPush(domain, webPushDTO, null);
+
+            // Assert
+            Assert.NotNull(capturedFunctionToBeSimulated);
+
+            // simulate the captured function execution
+            await capturedFunctionToBeSimulated(CancellationToken.None);
+
+            messageQueuePublisherMock.Verify(
+                q => q.PublishAsync(
+                    It.Is<DopplerWebPushDTO>(dto => dto.MessageId == messageId &&
+                        (dto.ClickedEventEndpoint == null || dto.ReceivedEventEndpoint == null)
+                    ),
+                    It.Is<string>(queue => queue == $"{queueNamePrefix}.webpush.queue"),
+                    It.IsAny<CancellationToken>()
+                ),
+                Times.Once
+            );
+        }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderBase.cs
@@ -78,7 +78,12 @@ namespace Doppler.PushContact.WebPushSender.Senders
                             endpoint = message.Subscription.EndPoint,
                             p256DH = message.Subscription.Keys.P256DH,
                             auth = message.Subscription.Keys.Auth,
-                        }
+                            subscriptionExtraData = new
+                            {
+                                clickedEventEndpoint = message.ClickedEventEndpoint,
+                                receivedEventEndpoint = message.ReceivedEventEndpoint,
+                            },
+                        },
                     },
                     notificationTitle = message.Title,
                     notificationBody = message.Body,

--- a/Doppler.PushContact/Doppler.PushContact.csproj
+++ b/Doppler.PushContact/Doppler.PushContact.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Doppler.PushContact.Models\Doppler.PushContact.Models.csproj" />
     <ProjectReference Include="..\Doppler.PushContact.QueuingService\Doppler.PushContact.QueuingService.csproj" />
+    <ProjectReference Include="..\Doppler.PushContact.Transversal\Doppler.PushContact.Transversal.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.PushContact/Services/PushServicesExtensions.cs
+++ b/Doppler.PushContact/Services/PushServicesExtensions.cs
@@ -16,7 +16,7 @@ namespace Doppler.PushContact.Services
 
             services.AddScoped<IDomainService, DomainService>();
 
-            services.Configure<WebPushQueueSettings>(configuration.GetSection(nameof(WebPushQueueSettings)));
+            services.Configure<WebPushPublisherSettings>(configuration.GetSection(nameof(WebPushPublisherSettings)));
 
             return services;
         }

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -95,11 +95,8 @@ namespace Doppler.PushContact.Services
             CancellationToken cancellationToken
         )
         {
-            var encryptedContactId = EncryptionHelper.Encrypt(pushContactId, useBase64Url: true);
-            var encryptedMessageId = EncryptionHelper.Encrypt(messageDTO.MessageId.ToString(), useBase64Url: true);
-
-            var clickedEventEndpoint = SanityzeEndpointToRegisterEvent(_clickedEventEndpointPath, encryptedContactId, encryptedMessageId);
-            var receivedEventEndpoint = SanityzeEndpointToRegisterEvent(_receivedEventEndpointPath, encryptedContactId, encryptedMessageId);
+            var clickedEventEndpoint = SanityzeEndpointToRegisterEvent(_clickedEventEndpointPath, pushContactId, messageDTO.MessageId.ToString());
+            var receivedEventEndpoint = SanityzeEndpointToRegisterEvent(_receivedEventEndpointPath, pushContactId, messageDTO.MessageId.ToString());
 
             var webPushMessage = new DopplerWebPushDTO()
             {
@@ -146,16 +143,19 @@ namespace Doppler.PushContact.Services
             return DEFAULT_QUEUE_NAME;
         }
 
-        public string SanityzeEndpointToRegisterEvent(string endpointPath, string encryptedContactId, string encryptedMessageId)
+        public string SanityzeEndpointToRegisterEvent(string endpointPath, string pushContactId, string messageId)
         {
             if (string.IsNullOrEmpty(endpointPath) ||
-                string.IsNullOrEmpty(encryptedContactId) ||
-                string.IsNullOrEmpty(encryptedMessageId) ||
+                string.IsNullOrEmpty(pushContactId) ||
+                string.IsNullOrEmpty(messageId) ||
                 string.IsNullOrEmpty(_pushApiUrl)
             )
             {
                 return null;
             }
+
+            var encryptedContactId = EncryptionHelper.Encrypt(pushContactId, useBase64Url: true);
+            var encryptedMessageId = EncryptionHelper.Encrypt(messageId, useBase64Url: true);
 
             return endpointPath
                 .Replace("[pushApiUrl]", _pushApiUrl)

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -1,9 +1,8 @@
-using Doppler.PushContact.DTOs;
-using Doppler.PushContact.Models;
 using Doppler.PushContact.Models.DTOs;
 using Doppler.PushContact.QueuingService.MessageQueueBroker;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Queue;
+using Doppler.PushContact.Transversal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -89,6 +88,13 @@ namespace Doppler.PushContact.Services
             CancellationToken cancellationToken
         )
         {
+            var encryptedContactId = EncryptionHelper.Encrypt(pushContactId, useBase64Url: true);
+            var encryptedMessageId = EncryptionHelper.Encrypt(messageDTO.MessageId.ToString(), useBase64Url: true);
+
+            // TODO: handled endpoints from config file
+            var clickedEventEndpoint = $"http://localhost:10693/push-contacts/{encryptedContactId}/messages/{encryptedMessageId}/clicked";
+            var receivedEventEndpoint = $"http://localhost:10693/push-contacts/{encryptedContactId}/messages/{encryptedMessageId}/received";
+
             var webPushMessage = new DopplerWebPushDTO()
             {
                 Title = messageDTO.Title,
@@ -98,6 +104,8 @@ namespace Doppler.PushContact.Services
                 Subscription = subscription,
                 MessageId = messageDTO.MessageId,
                 PushContactId = pushContactId,
+                ClickedEventEndpoint = clickedEventEndpoint,
+                ReceivedEventEndpoint = receivedEventEndpoint,
             };
 
             string queueName = GetQueueName(subscription.EndPoint);

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -150,7 +150,8 @@ namespace Doppler.PushContact.Services
         {
             if (string.IsNullOrEmpty(endpointPath) ||
                 string.IsNullOrEmpty(encryptedContactId) ||
-                string.IsNullOrEmpty(encryptedMessageId)
+                string.IsNullOrEmpty(encryptedMessageId) ||
+                string.IsNullOrEmpty(_pushApiUrl)
             )
             {
                 return null;

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -35,7 +35,7 @@ namespace Doppler.PushContact.Services
             IMessageSender messageSender,
             ILogger<WebPushPublisherService> logger,
             IMessageQueuePublisher messageQueuePublisher,
-            IOptions<WebPushQueueSettings> webPushQueueSettings
+            IOptions<WebPushPublisherSettings> webPushQueueSettings
         )
         {
             _pushContactService = pushContactService;

--- a/Doppler.PushContact/Services/WebPushPublisherSettings.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherSettings.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Doppler.PushContact.Services
 {
-    public class WebPushQueueSettings
+    public class WebPushPublisherSettings
     {
         public Dictionary<string, List<string>> PushEndpointMappings { get; set; }
         public string ClickedEventEndpointPath { get; set; }

--- a/Doppler.PushContact/Services/WebPushQueueSettings.cs
+++ b/Doppler.PushContact/Services/WebPushQueueSettings.cs
@@ -5,5 +5,8 @@ namespace Doppler.PushContact.Services
     public class WebPushQueueSettings
     {
         public Dictionary<string, List<string>> PushEndpointMappings { get; set; }
+        public string ClickedEventEndpointPath { get; set; }
+        public string ReceivedEventEndpointPath { get; set; }
+        public string PushApiUrl { get; set; }
     }
 }

--- a/Doppler.PushContact/Startup.cs
+++ b/Doppler.PushContact/Startup.cs
@@ -5,6 +5,7 @@ using Doppler.PushContact.Repositories.Interfaces;
 using Doppler.PushContact.Services;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Queue;
+using Doppler.PushContact.Transversal;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -27,6 +28,11 @@ namespace Doppler.PushContact
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            // Initialize EncryptionHelper
+            services.Configure<EncryptionSettings>(Configuration.GetSection("EncryptionSettings"));
+            var encryptionSettings = Configuration.GetSection("EncryptionSettings").Get<EncryptionSettings>();
+            EncryptionHelper.Initialize(encryptionSettings.Key, encryptionSettings.IV);
+
             services.AddDopplerSecurity();
             services.AddHttpContextAccessor();
             services.AddPushMongoContext(Configuration);

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -43,7 +43,10 @@
       "mozilla": ["https://updates.push.services.mozilla.com"],
       "microsoft": ["https://wns.windows.com"],
       "apple": ["https://api.push.apple.com"]
-    }
+    },
+    "ClickedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",
+    "ReceivedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/received",
+    "PushApiUrl": "REPLACE_WITH_PUSH_API_URL"
   },
   "EncryptionSettings": {
     "Key": "KEY_TO_BE_REPLACED",

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -46,7 +46,7 @@
     },
     "ClickedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",
     "ReceivedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/received",
-    "PushApiUrl": "REPLACE_WITH_PUSH_API_URL"
+    "PushApiUrl": ""
   },
   "EncryptionSettings": {
     "Key": "KEY_TO_BE_REPLACED",

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -41,7 +41,7 @@
     "PushEndpointMappings": {
       "google": ["https://fcm.googleapis.com"],
       "mozilla": ["https://updates.push.services.mozilla.com"],
-      "microsoft": ["https://wns.windows.com"],
+      "microsoft": ["https://wns.windows.com","https://wns2-bl2p.notify.windows.com"],
       "apple": ["https://api.push.apple.com"]
     },
     "ClickedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -44,5 +44,9 @@
       "microsoft": ["https://wns.windows.com"],
       "apple": ["https://api.push.apple.com"]
     }
+  },
+  "EncryptionSettings": {
+    "Key": "KEY_TO_BE_REPLACED",
+    "IV": "IV_TO_BE_REPLACED"
   }
 }

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -37,7 +37,7 @@
     "ConnectionString": "REPLACE_WITH_RABBITMQ_CONNECTIONSTRING",
     "Password": "REPLACE_WITH_RABBITMQ_PASSWORD"
   },
-  "WebPushQueueSettings": {
+  "WebPushPublisherSettings": {
     "PushEndpointMappings": {
       "google": ["https://fcm.googleapis.com"],
       "mozilla": ["https://updates.push.services.mozilla.com"],

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -41,7 +41,10 @@
     "PushEndpointMappings": {
       "google": ["https://fcm.googleapis.com"],
       "mozilla": ["https://updates.push.services.mozilla.com"],
-      "microsoft": ["https://wns.windows.com","https://wns2-bl2p.notify.windows.com"],
+      "microsoft": [
+        "https://wns.windows.com",
+        "https://wns2-bl2p.notify.windows.com"
+      ],
       "apple": ["https://api.push.apple.com"]
     },
     "ClickedEventEndpointPath": "[pushApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",


### PR DESCRIPTION
Add support to register clicked and received events when enqueueing messages, and sending webpush.

**Missing:** add new endpoints to process and register both events