### PR TITLE
Dop 1602 fix treatment when try to insert duplicated pushcontact

### DIFF
--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -103,6 +103,11 @@ namespace Doppler.PushContact.Services
             {
                 await PushContacts.InsertOneAsync(pushContactDocument);
             }
+            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                // If a duplicate key error is encountered, treat it as a success and proceed
+                _logger.LogInformation($"Duplicate key error for {nameof(pushContactModel.DeviceToken)}: {pushContactModel.DeviceToken}. Treating as successful insert.");
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, @$"Error inserting {nameof(pushContactModel)}


### PR DESCRIPTION
When it tries to add a contact with a duplicated `deviceToken`, the service will treat it as successful insert.