### PR TITLE
Dop 1851 improve performance getting contacts

### DIFF
--- a/Doppler.PushContact.Test/Controllers/MessageControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/MessageControllerTest.cs
@@ -808,8 +808,8 @@ namespace Doppler.PushContact.Test.Controllers
             _output.WriteLine(response.GetHeadersAsString());
 
             // Assert
-            // verify ProcessWebPush was called once
-            webPushPublisherServiceMock.Verify(x => x.ProcessWebPush(domain, It.IsAny<WebPushDTO>(), It.IsAny<string>()), Times.Once);
+            // verify ProcessWebPushInBatches was called once
+            webPushPublisherServiceMock.Verify(x => x.ProcessWebPushInBatches(domain, It.IsAny<WebPushDTO>(), It.IsAny<string>()), Times.Once);
 
             Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 

--- a/Doppler.PushContact.Test/Doppler.PushContact.Test.csproj
+++ b/Doppler.PushContact.Test/Doppler.PushContact.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.33" />
     <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Doppler.PushContact/Controllers/MessageController.cs
+++ b/Doppler.PushContact/Controllers/MessageController.cs
@@ -139,7 +139,7 @@ namespace Doppler.PushContact.Controllers
 
             var authenticationApiToken = await HttpContext.GetTokenAsync("Bearer", "access_token");
 
-            _webPushPublisherService.ProcessWebPush(domain, webPushDTO, authenticationApiToken);
+            _webPushPublisherService.ProcessWebPushInBatches(domain, webPushDTO, authenticationApiToken);
 
             return Accepted(new MessageResult()
             {

--- a/Doppler.PushContact/Properties/AssemblyInfo.cs
+++ b/Doppler.PushContact/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// da permiso de los metodos internal del proyecto, al proyecto Doppler.PushContact.Test
+[assembly: InternalsVisibleTo("Doppler.PushContact.Test")]
+// da permiso a Castle DynamicProxy, que es el motor usado por Moq para crear los mocks de clases y métodos internos.
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Doppler.PushContact/Repositories/Interfaces/IPushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/Interfaces/IPushContactRepository.cs
@@ -1,5 +1,6 @@
 using Doppler.PushContact.DTOs;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Doppler.PushContact.Repositories.Interfaces
@@ -7,5 +8,6 @@ namespace Doppler.PushContact.Repositories.Interfaces
     public interface IPushContactRepository
     {
         Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByDomainAsync(string domain);
+        IAsyncEnumerable<SubscriptionInfoDTO> GetSubscriptionInfoByDomainAsStreamAsync(string domain, CancellationToken cancellationToken = default);
     }
 }

--- a/Doppler.PushContact/Repositories/PushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/PushContactRepository.cs
@@ -10,6 +10,8 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Doppler.PushContact.Repositories
@@ -61,6 +63,110 @@ namespace Doppler.PushContact.Repositories
 
                 throw;
             }
+        }
+
+        public async IAsyncEnumerable<SubscriptionInfoDTO> GetSubscriptionInfoByDomainAsStreamAsync(
+        string domain,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        )
+        {
+            if (string.IsNullOrEmpty(domain))
+            {
+                throw new ArgumentException($"'{nameof(domain)}' cannot be null or empty.", nameof(domain));
+            }
+
+            var sizeFromConfig = _pushMongoContextSettings?.Value?.CursorBatchSize ?? 0;
+            var batchSize = sizeFromConfig > 0 ? sizeFromConfig : 500;
+
+            var filter = Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DomainPropName, domain) &
+                         Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DeletedPropName, false);
+
+            var options = new FindOptions<BsonDocument>
+            {
+                Projection = Builders<BsonDocument>.Projection
+                    .Include(PushContactDocumentProps.DeviceTokenPropName)
+                    .Include(PushContactDocumentProps.Subscription_PropName)
+                    .Include(PushContactDocumentProps.IdPropName),
+                BatchSize = batchSize // numbers of documents readed in each cursor page
+            };
+
+            // define cursor
+            using var cursor = await PushContacts.FindAsync(filter, options, cancellationToken);
+
+            var index = 0;
+            while (await cursor.MoveNextAsync(cancellationToken)) // read next page
+            {
+                index++;
+                _logger.LogDebug("number of page read from DB: {PageIndex}", index);
+                foreach (var doc in cursor.Current) // iterate docs of current page
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.LogWarning("Streaming cancelled while retrieving subscription info for domain: {Domain}", domain);
+                        yield break;
+                    }
+
+                    // take advantage of IAsyncEnumerable<> to return one item at a time (streaming by one)
+                    yield return GetSubscriptionInfoFromBson(doc);
+                }
+            }
+        }
+
+        private SubscriptionInfoDTO GetSubscriptionInfoFromBson(BsonDocument doc)
+        {
+            var DEVTOKEN_PROP_NAME = PushContactDocumentProps.DeviceTokenPropName;
+            var SUBSCRIPTION_PROP_NAME = PushContactDocumentProps.Subscription_PropName;
+            var ENDPOINT_PROP_NAME = PushContactDocumentProps.Subscription_EndPoint_PropName;
+            var AUTH_PROP_NAME = PushContactDocumentProps.Subscription_Auth_PropName;
+            var P256DH_PROP_NAME = PushContactDocumentProps.Subscription_P256DH_PropName;
+            var ID_PROP_NAME = PushContactDocumentProps.IdPropName;
+
+            var deviceToken = doc.Contains(DEVTOKEN_PROP_NAME) && !doc[DEVTOKEN_PROP_NAME].IsBsonNull
+                ? doc[DEVTOKEN_PROP_NAME].AsString
+                : null;
+
+            var pushContactId = doc.Contains(ID_PROP_NAME) && !doc[ID_PROP_NAME].IsBsonNull
+                ? doc[ID_PROP_NAME].ToString()
+                : null;
+
+            SubscriptionDTO subscriptionModel = null;
+
+            if (doc.Contains(SUBSCRIPTION_PROP_NAME) && !doc[SUBSCRIPTION_PROP_NAME].IsBsonNull)
+            {
+                var subscriptionDoc = doc[SUBSCRIPTION_PROP_NAME].AsBsonDocument;
+
+                var endPoint = subscriptionDoc.Contains(ENDPOINT_PROP_NAME) && !subscriptionDoc[ENDPOINT_PROP_NAME].IsBsonNull
+                    ? subscriptionDoc[ENDPOINT_PROP_NAME].AsString
+                    : null;
+
+                var auth = subscriptionDoc.Contains(AUTH_PROP_NAME) && !subscriptionDoc[AUTH_PROP_NAME].IsBsonNull
+                    ? subscriptionDoc[AUTH_PROP_NAME].AsString
+                    : null;
+
+                var p256dh = subscriptionDoc.Contains(P256DH_PROP_NAME) && !subscriptionDoc[P256DH_PROP_NAME].IsBsonNull
+                    ? subscriptionDoc[P256DH_PROP_NAME].AsString
+                    : null;
+
+                if (!string.IsNullOrEmpty(endPoint) && !string.IsNullOrEmpty(auth) && !string.IsNullOrEmpty(p256dh))
+                {
+                    subscriptionModel = new SubscriptionDTO
+                    {
+                        EndPoint = endPoint,
+                        Keys = new SubscriptionKeys
+                        {
+                            Auth = auth,
+                            P256DH = p256dh
+                        }
+                    };
+                }
+            }
+
+            return new SubscriptionInfoDTO
+            {
+                DeviceToken = deviceToken,
+                Subscription = subscriptionModel,
+                PushContactId = pushContactId
+            };
         }
 
         private List<SubscriptionInfoDTO> GetSubscriptionsInfoFromBsonDocuments(List<BsonDocument> pushContacts)

--- a/Doppler.PushContact/Repositories/PushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/PushContactRepository.cs
@@ -171,64 +171,7 @@ namespace Doppler.PushContact.Repositories
 
         private List<SubscriptionInfoDTO> GetSubscriptionsInfoFromBsonDocuments(List<BsonDocument> pushContacts)
         {
-            return pushContacts.Select(x =>
-            {
-                var DEVTOKEN_PROP_NAME = PushContactDocumentProps.DeviceTokenPropName;
-                var SUBSCRIPTION_PROP_NAME = PushContactDocumentProps.Subscription_PropName;
-                var ENDPOINT_PROP_NAME = PushContactDocumentProps.Subscription_EndPoint_PropName;
-                var AUTH_PROP_NAME = PushContactDocumentProps.Subscription_Auth_PropName;
-                var P256DH_PROP_NAME = PushContactDocumentProps.Subscription_P256DH_PropName;
-                var _ID_PROP_NAME = PushContactDocumentProps.IdPropName;
-
-                var deviceToken = x.Contains(DEVTOKEN_PROP_NAME) && !x[DEVTOKEN_PROP_NAME].IsBsonNull
-                    ? x[DEVTOKEN_PROP_NAME].AsString
-                    : null;
-
-                var _id = x[_ID_PROP_NAME].AsString;
-
-                if (x.Contains(SUBSCRIPTION_PROP_NAME) && !x[SUBSCRIPTION_PROP_NAME].IsBsonNull)
-                {
-                    var subscriptionDoc = x[SUBSCRIPTION_PROP_NAME].AsBsonDocument;
-
-                    var endPoint = subscriptionDoc.Contains(ENDPOINT_PROP_NAME) && !subscriptionDoc[ENDPOINT_PROP_NAME].IsBsonNull
-                        ? subscriptionDoc[ENDPOINT_PROP_NAME].AsString
-                        : null;
-
-                    var auth = subscriptionDoc.Contains(AUTH_PROP_NAME) && !subscriptionDoc[AUTH_PROP_NAME].IsBsonNull
-                        ? subscriptionDoc[AUTH_PROP_NAME].AsString
-                        : null;
-
-                    var p256dh = subscriptionDoc.Contains(P256DH_PROP_NAME) && !subscriptionDoc[P256DH_PROP_NAME].IsBsonNull
-                        ? subscriptionDoc[P256DH_PROP_NAME].AsString
-                        : null;
-
-                    var subscriptionModel = new SubscriptionDTO
-                    {
-                        EndPoint = endPoint,
-                        Keys = new SubscriptionKeys
-                        {
-                            Auth = auth,
-                            P256DH = p256dh
-                        }
-                    };
-
-                    return new SubscriptionInfoDTO
-                    {
-                        DeviceToken = deviceToken,
-                        Subscription = subscriptionModel,
-                        PushContactId = _id,
-                    };
-                }
-                else
-                {
-                    return new SubscriptionInfoDTO
-                    {
-                        DeviceToken = deviceToken,
-                        Subscription = null,
-                        PushContactId = _id,
-                    };
-                }
-            }).ToList();
+            return pushContacts.Select(GetSubscriptionInfoFromBson).ToList();
         }
 
         private IMongoCollection<BsonDocument> PushContacts

--- a/Doppler.PushContact/Repositories/PushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/PushContactRepository.cs
@@ -78,8 +78,8 @@ namespace Doppler.PushContact.Repositories
             var sizeFromConfig = _pushMongoContextSettings?.Value?.CursorBatchSize ?? 0;
             var batchSize = sizeFromConfig > 0 ? sizeFromConfig : 500;
 
-            var filter = Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DomainPropName, domain) &
-                         Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DeletedPropName, false);
+            var filter = Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DomainPropName, domain)
+                & Builders<BsonDocument>.Filter.Eq(PushContactDocumentProps.DeletedPropName, false);
 
             var options = new FindOptions<BsonDocument>
             {

--- a/Doppler.PushContact/Services/IWebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/IWebPushPublisherService.cs
@@ -1,9 +1,11 @@
 using Doppler.PushContact.Models.DTOs;
+using System.Threading;
 
 namespace Doppler.PushContact.Services
 {
     public interface IWebPushPublisherService
     {
         void ProcessWebPush(string domain, WebPushDTO webPushDTO, string authenticationApiToken = null);
+        void ProcessWebPushInBatches(string domain, WebPushDTO messageDTO, string authenticationApiToken = null);
     }
 }

--- a/Doppler.PushContact/Services/PushMongoContextExtensions.cs
+++ b/Doppler.PushContact/Services/PushMongoContextExtensions.cs
@@ -30,6 +30,8 @@ namespace Doppler.PushContact.Services
                 {
                     var mongoClient = new MongoClient(mongoUrl);
                     var database = mongoClient.GetDatabase(pushMongoContextSettings.DatabaseName);
+
+                    // push-contacts indexes
                     var pushContacts = database.GetCollection<BsonDocument>(pushMongoContextSettings.PushContactsCollectionName);
 
                     var deviceTokenAsUniqueIndex = new CreateIndexModel<BsonDocument>(
@@ -42,6 +44,14 @@ namespace Doppler.PushContact.Services
                     new CreateIndexOptions { Unique = false });
                     pushContacts.Indexes.CreateOne(domainAsSingleFieldIndex);
 
+                    var domainAndDeletedIndex = new CreateIndexModel<BsonDocument>(
+                    Builders<BsonDocument>.IndexKeys
+                        .Ascending(PushContactDocumentProps.DomainPropName)
+                        .Ascending(PushContactDocumentProps.DeletedPropName),
+                    new CreateIndexOptions { Unique = false });
+                    pushContacts.Indexes.CreateOne(domainAndDeletedIndex);
+
+                    // domains indexes
                     var domains = database.GetCollection<BsonDocument>(pushMongoContextSettings.DomainsCollectionName);
 
                     var domainNameAsUniqueIndex = new CreateIndexModel<BsonDocument>(
@@ -49,6 +59,7 @@ namespace Doppler.PushContact.Services
                     new CreateIndexOptions { Unique = true });
                     domains.Indexes.CreateOne(domainNameAsUniqueIndex);
 
+                    // messages indexes
                     var messages = database.GetCollection<BsonDocument>(pushMongoContextSettings.MessagesCollectionName);
 
                     var messageIdAsUniqueIndex = new CreateIndexModel<BsonDocument>(

--- a/Doppler.PushContact/Services/PushMongoContextSettings.cs
+++ b/Doppler.PushContact/Services/PushMongoContextSettings.cs
@@ -14,5 +14,6 @@ namespace Doppler.PushContact.Services
 
         public string MessagesCollectionName { get; set; }
         public string WebPushEventCollectionName { get; set; }
+        public int CursorBatchSize { get; set; }
     }
 }

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -183,7 +183,7 @@ namespace Doppler.PushContact.Services
             });
         }
 
-        private async Task ProcessWebPushBatchAsync(IEnumerable<SubscriptionInfoDTO> batch, WebPushDTO messageDTO, CancellationToken cancellationToken)
+        internal virtual async Task ProcessWebPushBatchAsync(IEnumerable<SubscriptionInfoDTO> batch, WebPushDTO messageDTO, CancellationToken cancellationToken)
         {
             await Parallel.ForEachAsync(batch, cancellationToken, async (subscription, ct) =>
             {

--- a/Doppler.PushContact/Services/WebPushPublisherSettings.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherSettings.cs
@@ -8,5 +8,6 @@ namespace Doppler.PushContact.Services
         public string ClickedEventEndpointPath { get; set; }
         public string ReceivedEventEndpointPath { get; set; }
         public string PushContactApiUrl { get; set; }
+        public int ProcessPushBatchSize { get; set; }
     }
 }

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -23,7 +23,8 @@
     "PushContactsCollectionName": "REPLACE_WITH_MONGODB_PUSH_CONTACTS_COLLECTION_NAME",
     "DomainsCollectionName": "REPLACE_WITH_MONGODB_DOMAINS_COLLECTION_NAME",
     "MessagesCollectionName": "messages",
-    "WebPushEventCollectionName": "webPushEvent"
+    "WebPushEventCollectionName": "webPushEvent",
+    "CursorBatchSize": 500
   },
   "DeviceTokenValidatorSettings": {
     "PushApiUrl": "REPLACE_WITH_PUSH_API_URL"

--- a/Doppler.PushContact/appsettings.json
+++ b/Doppler.PushContact/appsettings.json
@@ -50,7 +50,8 @@
     },
     "ClickedEventEndpointPath": "[pushContactApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/clicked",
     "ReceivedEventEndpointPath": "[pushContactApiUrl]/push-contacts/[encryptedContactId]/messages/[encryptedMessageId]/received",
-    "PushContactApiUrl": ""
+    "PushContactApiUrl": "",
+    "ProcessPushBatchSize": 500
   },
   "EncryptionSettings": {
     "Key": "KEY_TO_BE_REPLACED",


### PR DESCRIPTION
Mejorar la performance en la obtencion de los contactos al momento de enviar push:
- se agregó nuevo indice en `push-contacts`: `{ domain: 1, deleted: 1 }`
- se agregó un metodo para obtener la informacion de los contactos de la base usando cursor: `GetSubscriptionInfoByDomainAsStreamAsync `
- se agregó un metodo para procesar los envios de push por batches (por subscripcion y/o device token): `ProcessWebPushInBatches`