### PR TITLE
Dop 1851 fix message counters summarization

### DIFF
--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -78,9 +78,9 @@ namespace Doppler.PushContact.Services.Messages
                 .Eq(MessageDocumentProps.MessageIdPropName, new BsonBinaryData(messageId, GuidRepresentation.Standard));
 
             var updateDefinition = Builders<BsonDocument>.Update
-                .Set(MessageDocumentProps.SentPropName, sent)
-                .Set(MessageDocumentProps.DeliveredPropName, delivered)
-                .Set(MessageDocumentProps.NotDeliveredPropName, notDelivered);
+                .Inc(MessageDocumentProps.SentPropName, sent)
+                .Inc(MessageDocumentProps.DeliveredPropName, delivered)
+                .Inc(MessageDocumentProps.NotDeliveredPropName, notDelivered);
 
             try
             {
@@ -88,9 +88,7 @@ namespace Doppler.PushContact.Services.Messages
             }
             catch (Exception e)
             {
-                _logger.LogError(e, @$"Error updating message with {nameof(messageId)} {messageId}");
-
-                throw;
+                _logger.LogError(e, @$"Error updating message counters with {nameof(messageId)} {messageId}");
             }
         }
 


### PR DESCRIPTION
Fix del update de los contadores en la collection de `messages`.
Antes del **tratamiento por batches**, se hacia el envio de un mensaje a todos los `push-contacts`, y luego se actualizaban de una los contadores de `messages`. Ahora, al **procesar por batches**, debe ir **incrementandose esos valores** cuando se procesa cada **batch de tokens**.