### PR TITLE
No ticket consider domain sending by visitorguid

### DIFF
--- a/Doppler.PushContact.Test/Repositories/PushContactRepositoryTest.cs
+++ b/Doppler.PushContact.Test/Repositories/PushContactRepositoryTest.cs
@@ -319,11 +319,14 @@ namespace Doppler.PushContact.Test.Repositories
             (string visitorGuid)
         {
             // Arrange
+            Fixture fixture = new Fixture();
+            var domain = fixture.Create<string>();
+
             var sut = CreateSut();
 
             // Act
             // Assert
-            var result = await Assert.ThrowsAsync<ArgumentException>(() => sut.GetAllSubscriptionInfoByVisitorGuidAsync(visitorGuid));
+            var result = await Assert.ThrowsAsync<ArgumentException>(() => sut.GetAllSubscriptionInfoByVisitorGuidAsync(domain, visitorGuid));
         }
 
         [Fact]
@@ -335,6 +338,7 @@ namespace Doppler.PushContact.Test.Repositories
             var pushMongoContextSettings = fixture.Create<PushMongoContextSettings>();
 
             var visitorGuid = fixture.Create<string>();
+            var domain = fixture.Create<string>();
 
             var pushContactsCollectionMock = new Mock<IMongoCollection<BsonDocument>>();
             pushContactsCollectionMock
@@ -360,7 +364,7 @@ namespace Doppler.PushContact.Test.Repositories
 
             // Act
             // Assert
-            await Assert.ThrowsAsync<Exception>(() => sut.GetAllSubscriptionInfoByVisitorGuidAsync(visitorGuid));
+            await Assert.ThrowsAsync<Exception>(() => sut.GetAllSubscriptionInfoByVisitorGuidAsync(domain, visitorGuid));
 
             loggerMock.Verify(
                 x => x.Log(
@@ -382,7 +386,8 @@ namespace Doppler.PushContact.Test.Repositories
             int randomPushContactIndex = random.Next(allPushContactDocuments.Count);
             var visitorGuidFilter = allPushContactDocuments[randomPushContactIndex][PushContactDocumentProps.VisitorGuidPropName].AsString;
 
-            var fixture = new Fixture();
+            Fixture fixture = new Fixture();
+            var domain = fixture.Create<string>();
 
             var pushMongoContextSettings = fixture.Create<PushMongoContextSettings>();
 
@@ -421,7 +426,7 @@ namespace Doppler.PushContact.Test.Repositories
                 Options.Create(pushMongoContextSettings));
 
             // Act
-            var result = await sut.GetAllSubscriptionInfoByVisitorGuidAsync(visitorGuidFilter);
+            var result = await sut.GetAllSubscriptionInfoByVisitorGuidAsync(domain, visitorGuidFilter);
 
             // Assert
             Assert.All(result, res => allPushContactDocuments

--- a/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushPublisherServiceTest.cs
@@ -823,7 +823,7 @@ namespace Doppler.PushContact.Test.Services
 
             // verifica que NO se llamaron metodos
             messageSenderMock.Verify(m => m.SendFirebaseWebPushAsync(It.IsAny<WebPushDTO>(), It.IsAny<List<string>>(), It.IsAny<string>()), Times.Never);
-            pushContactRepositoryMock.Verify(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(It.IsAny<string>()), Times.Never);
+            pushContactRepositoryMock.Verify(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
             // verifica que se logueo el warning
             loggerMock.Verify(
@@ -842,11 +842,13 @@ namespace Doppler.PushContact.Test.Services
             // Arrange
             var fixture = new Fixture();
             var visitorGuid = fixture.Create<string>();
+            var domain = fixture.Create<string>();
             var webPushDTO = new WebPushDTO
             {
                 Title = fixture.Create<string>(),
                 Body = fixture.Create<string>(),
-                MessageId = fixture.Create<Guid>()
+                MessageId = fixture.Create<Guid>(),
+                Domain = domain,
             };
 
             var visitorsWithReplacements = new FieldsReplacementList()
@@ -871,7 +873,7 @@ namespace Doppler.PushContact.Test.Services
 
             var pushContactRepositoryMock = new Mock<IPushContactRepository>();
             pushContactRepositoryMock
-                .Setup(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(visitorGuid))
+                .Setup(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(domain, visitorGuid))
                 .Throws(expectedException);
 
             var loggerMock = new Mock<ILogger<WebPushPublisherService>>();
@@ -1021,7 +1023,7 @@ namespace Doppler.PushContact.Test.Services
                 Times.Once);
 
             // verifica que NO se intentan obtener las subscripciones/tokens para el visitor
-            pushContactRepositoryMock.Verify(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(It.IsAny<string>()), Times.Never);
+            pushContactRepositoryMock.Verify(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
@@ -1031,11 +1033,14 @@ namespace Doppler.PushContact.Test.Services
             var fixture = new Fixture();
             var visitorGuid = fixture.Create<string>();
             var messageId = fixture.Create<Guid>();
+            var domain = fixture.Create<string>();
+
             var webPushDTO = new WebPushDTO
             {
                 Title = fixture.Create<string>(),
                 Body = fixture.Create<string>(),
                 MessageId = messageId,
+                Domain = domain,
             };
 
             var visitorFields1 = new VisitorFields
@@ -1065,7 +1070,7 @@ namespace Doppler.PushContact.Test.Services
             var backgroundQueueMock = new Mock<IBackgroundQueue>();
             var pushContactRepositoryMock = new Mock<IPushContactRepository>();
             pushContactRepositoryMock
-                .Setup(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(visitorGuid))
+                .Setup(r => r.GetAllSubscriptionInfoByVisitorGuidAsync(domain, visitorGuid))
                 .ReturnsAsync(subscriptions);
 
             var messageSenderMock = new Mock<IMessageSender>();

--- a/Doppler.PushContact/Repositories/Interfaces/IPushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/Interfaces/IPushContactRepository.cs
@@ -10,7 +10,7 @@ namespace Doppler.PushContact.Repositories.Interfaces
     {
         Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByDomainAsync(string domain);
         IAsyncEnumerable<SubscriptionInfoDTO> GetSubscriptionInfoByDomainAsStreamAsync(string domain, CancellationToken cancellationToken = default);
-        Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByVisitorGuidAsync(string visitorGuid);
+        Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByVisitorGuidAsync(string domain, string visitorGuid);
         Task<ContactsStatsDTO> GetContactsStatsAsync(string domainName);
         Task<VisitorInfoDTO> GetVisitorInfoSafeAsync(string deviceToken);
     }

--- a/Doppler.PushContact/Repositories/PushContactRepository.cs
+++ b/Doppler.PushContact/Repositories/PushContactRepository.cs
@@ -112,7 +112,7 @@ namespace Doppler.PushContact.Repositories
             }
         }
 
-        public async Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByVisitorGuidAsync(string visitorGuid)
+        public async Task<IEnumerable<SubscriptionInfoDTO>> GetAllSubscriptionInfoByVisitorGuidAsync(string domain, string visitorGuid)
         {
             if (string.IsNullOrEmpty(visitorGuid))
             {
@@ -122,7 +122,8 @@ namespace Doppler.PushContact.Repositories
             var filterBuilder = Builders<BsonDocument>.Filter;
 
             var filter = filterBuilder.Eq(PushContactDocumentProps.VisitorGuidPropName, visitorGuid)
-                & filterBuilder.Eq(PushContactDocumentProps.DeletedPropName, false);
+                & filterBuilder.Eq(PushContactDocumentProps.DeletedPropName, false)
+                & filterBuilder.Eq(PushContactDocumentProps.DomainPropName, domain);
 
             var options = new FindOptions<BsonDocument>
             {

--- a/Doppler.PushContact/Services/PushMongoContextExtensions.cs
+++ b/Doppler.PushContact/Services/PushMongoContextExtensions.cs
@@ -58,6 +58,15 @@ namespace Doppler.PushContact.Services
                     );
                     pushContacts.Indexes.CreateOne(deletedAndDomainAndVisitorGuidIndex);
 
+                    var VisitorGuidAndDomainAndDeletedIndex = new CreateIndexModel<BsonDocument>(
+                        Builders<BsonDocument>.IndexKeys
+                            .Ascending(PushContactDocumentProps.VisitorGuidPropName)
+                            .Ascending(PushContactDocumentProps.DomainPropName)
+                            .Ascending(PushContactDocumentProps.DeletedPropName),
+                        new CreateIndexOptions { Unique = false }
+                    );
+                    pushContacts.Indexes.CreateOne(VisitorGuidAndDomainAndDeletedIndex);
+
                     // domains indexes
                     var domains = database.GetCollection<BsonDocument>(pushMongoContextSettings.DomainsCollectionName);
 

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -389,7 +389,6 @@ namespace Doppler.PushContact.Services
                 _logger.LogDebug($"Message with replaced fields: {JsonSerializer.Serialize(messageWithReplacedFields)}");
 
                 var deviceTokens = new List<string>();
-                // TODO:
                 var subscriptionsInfo = await _pushContactRepository.GetAllSubscriptionInfoByVisitorGuidAsync(messageDTO.Domain, visitorWithFields.VisitorGuid);
                 foreach (var subscription in subscriptionsInfo)
                 {

--- a/Doppler.PushContact/Services/WebPushPublisherService.cs
+++ b/Doppler.PushContact/Services/WebPushPublisherService.cs
@@ -389,7 +389,8 @@ namespace Doppler.PushContact.Services
                 _logger.LogDebug($"Message with replaced fields: {JsonSerializer.Serialize(messageWithReplacedFields)}");
 
                 var deviceTokens = new List<string>();
-                var subscriptionsInfo = await _pushContactRepository.GetAllSubscriptionInfoByVisitorGuidAsync(visitorWithFields.VisitorGuid);
+                // TODO:
+                var subscriptionsInfo = await _pushContactRepository.GetAllSubscriptionInfoByVisitorGuidAsync(messageDTO.Domain, visitorWithFields.VisitorGuid);
                 foreach (var subscription in subscriptionsInfo)
                 {
                     if (subscription.Subscription != null &&


### PR DESCRIPTION
Considerar el dominio al que pertenece el mensaje al momento de obtener las subscripciones para un contacto con un determinado `visitor_guid`. Si el **dominio del `message`** no coincide con el **dominio del `push-contact`** la subscripcion no sera considerada para hacer el envio.