### PR TITLE
Dop 1880 unify historyevents with webpushevents

### DIFF
--- a/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
+++ b/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
@@ -1,4 +1,4 @@
-namespace Doppler.PushContact.Services.Messages
+namespace Doppler.PushContact.Models.Entities
 {
     public static class MessageDocumentProps
     {

--- a/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
+++ b/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
@@ -23,5 +23,7 @@ namespace Doppler.PushContact.Models.Entities
         public const string InsertedDatePropName = "inserted_date";
 
         public const string ImageUrlPropName = "image_url";
+
+        public const string BillableSendsPropName = "billable_sends";
     }
 }

--- a/Doppler.PushContact.Models/Entities/WebPushEvent.cs
+++ b/Doppler.PushContact.Models/Entities/WebPushEvent.cs
@@ -26,5 +26,8 @@ namespace Doppler.PushContact.Models.Entities
 
         [BsonElement(WebPushEventDocumentProps.Domain_PropName)]
         public string Domain { get; set; }
+
+        [BsonElement(WebPushEventDocumentProps.DeviceToken_PropName)]
+        public string DeviceToken { get; set; }
     }
 }

--- a/Doppler.PushContact.Models/Entities/WebPushEventDocumentProps.cs
+++ b/Doppler.PushContact.Models/Entities/WebPushEventDocumentProps.cs
@@ -10,5 +10,6 @@ namespace Doppler.PushContact.Models.Entities
         public const string ErrorMessage_PropName = "error_message";
         public const string SubType_PropName = "sub_type";
         public const string Domain_PropName = "domain";
+        public const string DeviceToken_PropName = "device_token";
     }
 }

--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -3513,7 +3513,7 @@ namespace Doppler.PushContact.Test.Controllers
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact]
+        [Fact(Skip = "It doesn't apply anymore. Now, the webpushevent's are not summarized.")]
         public async Task GetMessageDetails_should_return_ok_summarizing_webpushevents_and_message_stats_when_message_has_stats()
         {
             // Arrange

--- a/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/PushContactControllerTest.cs
@@ -2464,7 +2464,7 @@ namespace Doppler.PushContact.Test.Controllers
             var response = await client.SendAsync(request);
 
             // Assert
-            pushContactServiceMock.Verify(x => x.AddHistoryEventsAndMarkDeletedContactsAsync(It.IsAny<Guid>(), sendMessageResult), Times.Once());
+            pushContactServiceMock.Verify(x => x.MarkDeletedContactsAsync(It.IsAny<Guid>(), sendMessageResult), Times.Once());
         }
 
         [Fact]

--- a/Doppler.PushContact.Test/Repositories/WebPushEventRepositoryTest.cs
+++ b/Doppler.PushContact.Test/Repositories/WebPushEventRepositoryTest.cs
@@ -368,7 +368,7 @@ namespace Doppler.PushContact.Test.Repositories
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("Error summarizing 'WebPushEvents' for domain:")),
+                    It.Is<It.IsAnyType>((o, t) => o.ToString().Contains("Error summarizing billable 'WebPushEvents' for domain:")),
                     It.IsAny<Exception>(),
                     It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                 Times.Once

--- a/Doppler.PushContact.Test/Services/Messages/MessageRepositoryTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageRepositoryTest.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System;
 using Xunit;
 using MongoDB.Bson.Serialization;
+using Doppler.PushContact.Models.Entities;
 
 namespace Doppler.PushContact.Test.Services.Messages
 {

--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using Doppler.PushContact.Models.DTOs;
+using Doppler.PushContact.Models.Entities;
 using Doppler.PushContact.Services;
 using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Services.Messages.ExternalContracts;
@@ -7,7 +8,6 @@ using Flurl.Http;
 using Flurl.Http.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using Moq;
 using System;
@@ -538,7 +538,7 @@ namespace Doppler.PushContact.Test.Services.Messages
                 .WithVerb(HttpMethod.Post)
                 .Times(1);
             mockPushContactService.Verify(x => x.MarkDeletedContactsAsync(webPushDTO.MessageId, It.IsAny<SendMessageResult>()), Times.Once);
-            mockMessageRepository.Verify(x => x.UpdateDeliveriesAsync(webPushDTO.MessageId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+            mockMessageRepository.Verify(x => x.RegisterStatisticsAsync(webPushDTO.MessageId, It.IsAny<IEnumerable<WebPushEvent>>()), Times.Once);
             mockWebPushEventService.Verify(x => x.RegisterWebPushEventsAsync(webPushDTO.Domain, webPushDTO.MessageId, It.IsAny<SendMessageResult>()), Times.Once);
         }
 

--- a/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
+++ b/Doppler.PushContact.Test/Services/Messages/MessageSenderTest.cs
@@ -417,7 +417,7 @@ namespace Doppler.PushContact.Test.Services.Messages
             // Assert
             // verify that none the involved services were called
             mockPushApiTokenGetter.Verify(x => x.GetTokenAsync(), Times.Never);
-            mockMessageRepository.Verify(x => x.UpdateDeliveriesAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+            mockMessageRepository.Verify(x => x.RegisterStatisticsAsync(It.IsAny<Guid>(), It.IsAny<IEnumerable<WebPushEvent>>()), Times.Never);
             mockPushContactService.Verify(x => x.MarkDeletedContactsAsync(It.IsAny<Guid>(), It.IsAny<SendMessageResult>()), Times.Never);
             mockWebPushEventService.Verify(x => x.RegisterWebPushEventsAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<SendMessageResult>()), Times.Never);
             httpTest.ShouldNotHaveMadeACall();

--- a/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/PushContactServiceTest.cs
@@ -1146,7 +1146,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             var sut = CreateSut();
             // Act
             // Assert
-            var result = await Assert.ThrowsAsync<ArgumentNullException>(() => sut.AddHistoryEventsAndMarkDeletedContactsAsync(messageId, null));
+            var result = await Assert.ThrowsAsync<ArgumentNullException>(() => sut.MarkDeletedContactsAsync(messageId, null));
         }
 
         [Theory]

--- a/Doppler.PushContact.Test/Services/WebPushEventServiceTest.cs
+++ b/Doppler.PushContact.Test/Services/WebPushEventServiceTest.cs
@@ -289,31 +289,24 @@ namespace Doppler.PushContact.Test.Services
             var to = DateTimeOffset.UtcNow;
 
             var webPushEventsConsumed = 10;
-            var messageConsumed = 20;
 
             var mockPushContactService = new Mock<IPushContactService>();
-            var mockMessageRepository = new Mock<IMessageRepository>();
             var mockWebPushEventRepository = new Mock<IWebPushEventRepository>();
 
             mockWebPushEventRepository
                 .Setup(repo => repo.GetWebPushEventConsumed(domain, from, to))
                 .ReturnsAsync(webPushEventsConsumed);
 
-            mockMessageRepository
-                .Setup(repo => repo.GetMessageSends(domain, from, to))
-                .ReturnsAsync(messageConsumed);
-
             var sut = CreateSut(
                 webPushEventRepository: mockWebPushEventRepository.Object,
-                pushContactService: mockPushContactService.Object,
-                messageRepository: mockMessageRepository.Object
+                pushContactService: mockPushContactService.Object
             );
 
             // Act
             var consumedResult = await sut.GetWebPushEventConsumed(domain, from, to);
 
             // Assert
-            Assert.Equal(webPushEventsConsumed + messageConsumed, consumedResult);
+            Assert.Equal(webPushEventsConsumed, consumedResult);
         }
     }
 }

--- a/Doppler.PushContact.WebPushSender.Test/Senders/DefaultWebPushSenderTest.cs
+++ b/Doppler.PushContact.WebPushSender.Test/Senders/DefaultWebPushSenderTest.cs
@@ -32,6 +32,7 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             ILogger<DefaultWebPushSender> logger = null,
             IWebPushEventRepository webPushEventRepository = null,
             IPushContactRepository pushContactRepository = null,
+            IMessageRepository messageRepository = null,
             SendWebPushDelegate sendWebPushDelegate = null
             )
         {
@@ -41,6 +42,7 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
                 logger ?? Mock.Of<ILogger<DefaultWebPushSender>>(),
                 webPushEventRepository ?? Mock.Of<IWebPushEventRepository>(),
                 pushContactRepository ?? Mock.Of<IPushContactRepository>(),
+                messageRepository ?? Mock.Of<IMessageRepository>(),
                 sendWebPushDelegate ?? Mock.Of<SendWebPushDelegate>()
             );
         }

--- a/Doppler.PushContact.WebPushSender.Test/Senders/Dummies/TestableDefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender.Test/Senders/Dummies/TestableDefaultWebPushSender.cs
@@ -22,8 +22,9 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders.Dummies
             ILogger<DefaultWebPushSender> logger,
             IWebPushEventRepository weshPushEventRepository,
             IPushContactRepository pushContactRepository,
+            IMessageRepository messageRepository,
             SendWebPushDelegate sendWebPushDelegate)
-            : base(webPushSenderSettings, messageQueueSubscriber, logger, weshPushEventRepository, pushContactRepository)
+            : base(webPushSenderSettings, messageQueueSubscriber, logger, weshPushEventRepository, pushContactRepository, messageRepository)
         {
             _sendWebPushDelegate = sendWebPushDelegate;
         }

--- a/Doppler.PushContact.WebPushSender.Test/Senders/WebPushSenderFactoryTest.cs
+++ b/Doppler.PushContact.WebPushSender.Test/Senders/WebPushSenderFactoryTest.cs
@@ -48,6 +48,7 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             var loggerMock = new Mock<ILogger<DefaultWebPushSender>>();
             var webPushEventRepository = new Mock<IWebPushEventRepository>();
             var pushContactRepository = new Mock<IPushContactRepository>();
+            var messageRepository = new Mock<IMessageRepository>();
 
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IMessageQueueSubscriber)))
@@ -64,6 +65,10 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IPushContactRepository)))
                 .Returns(pushContactRepository.Object);
+
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IMessageRepository)))
+                .Returns(messageRepository.Object);
 
             var webPushSenderSettings = Options.Create(new WebPushSenderSettings
             {
@@ -89,6 +94,7 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             var loggerMock = new Mock<ILogger<DefaultWebPushSender>>();
             var webPushEventRepository = new Mock<IWebPushEventRepository>();
             var pushContactRepository = new Mock<IPushContactRepository>();
+            var messageRepository = new Mock<IMessageRepository>();
 
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IMessageQueueSubscriber)))
@@ -105,6 +111,10 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IPushContactRepository)))
                 .Returns(pushContactRepository.Object);
+
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IMessageRepository)))
+                .Returns(messageRepository.Object);
 
             var webPushSenderSettings = Options.Create(new WebPushSenderSettings
             {
@@ -135,6 +145,7 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             var loggerMock = new Mock<ILogger<DefaultWebPushSender>>();
             var webPushEventRepository = new Mock<IWebPushEventRepository>();
             var pushContactRepository = new Mock<IPushContactRepository>();
+            var messageRepository = new Mock<IMessageRepository>();
 
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IMessageQueueSubscriber)))
@@ -151,6 +162,10 @@ namespace Doppler.PushContact.WebPushSender.Test.Senders
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(IPushContactRepository)))
                 .Returns(pushContactRepository.Object);
+
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IMessageRepository)))
+                .Returns(messageRepository.Object);
 
             var webPushSenderSettings = Options.Create(new WebPushSenderSettings
             {

--- a/Doppler.PushContact.WebPushSender/Repositories/Interfaces/IMessageRepository.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/Interfaces/IMessageRepository.cs
@@ -1,0 +1,11 @@
+using Doppler.PushContact.Models.Entities;
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender.Repositories.Interfaces
+{
+    public interface IMessageRepository
+    {
+        Task RegisterStatisticsAsync(Guid messageId, WebPushEvent webPushEvent);
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
@@ -30,12 +30,7 @@ namespace Doppler.PushContact.WebPushSender.Repositories
         {
             var sent = 1;
             var delivered = webPushEvent.Type == (int)WebPushEventType.Delivered ? 1 : 0;
-
-            // TODO: consider re-analyze summarization when ProcessingFailed and DeliveryFailedButRetry will be treated
-            var notDelivered =
-                webPushEvent.Type == (int)WebPushEventType.ProcessingFailed ||
-                webPushEvent.Type == (int)WebPushEventType.DeliveryFailed ||
-                webPushEvent.Type == (int)WebPushEventType.DeliveryFailedButRetry ? 1 : 0;
+            var notDelivered = sent - delivered;
 
             await UpdateDeliveriesSafe(messageId, sent, delivered, notDelivered);
         }

--- a/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
@@ -1,0 +1,63 @@
+using Doppler.PushContact.Models.Entities;
+using Doppler.PushContact.Models.Enums;
+using Doppler.PushContact.WebPushSender.Repositories.Interfaces;
+using Doppler.PushContact.WebPushSender.Repositories.Setup;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.WebPushSender.Repositories
+{
+    public class MessageRepository : IMessageRepository
+    {
+        private readonly IMongoCollection<BsonDocument> _collection;
+        private readonly ILogger<MessageRepository> _logger;
+
+        public MessageRepository(
+            IMongoDatabase database,
+            IOptions<RepositorySettings> repositorySettings,
+            ILogger<MessageRepository> logger
+        )
+        {
+            _collection = database.GetCollection<BsonDocument>(repositorySettings.Value.MessageCollectionName);
+            _logger = logger;
+        }
+
+        public async Task RegisterStatisticsAsync(Guid messageId, WebPushEvent webPushEvent)
+        {
+            var sent = 1;
+            var delivered = webPushEvent.Type == (int)WebPushEventType.Delivered ? 1 : 0;
+
+            // TODO: consider re-analyze summarization when ProcessingFailed and DeliveryFailedButRetry will be treated
+            var notDelivered =
+                webPushEvent.Type == (int)WebPushEventType.ProcessingFailed ||
+                webPushEvent.Type == (int)WebPushEventType.DeliveryFailed ||
+                webPushEvent.Type == (int)WebPushEventType.DeliveryFailedButRetry ? 1 : 0;
+
+            await UpdateDeliveriesSafe(messageId, sent, delivered, notDelivered);
+        }
+
+        private async Task UpdateDeliveriesSafe(Guid messageId, int sent, int delivered, int notDelivered)
+        {
+            var filterDefinition = Builders<BsonDocument>.Filter
+                .Eq(MessageDocumentProps.MessageIdPropName, new BsonBinaryData(messageId, GuidRepresentation.Standard));
+
+            var updateDefinition = Builders<BsonDocument>.Update
+                .Inc(MessageDocumentProps.SentPropName, sent)
+                .Inc(MessageDocumentProps.DeliveredPropName, delivered)
+                .Inc(MessageDocumentProps.NotDeliveredPropName, notDelivered);
+
+            try
+            {
+                await _collection.UpdateOneAsync(filterDefinition, updateDefinition);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error updating message counters with {nameof(messageId)} {messageId}");
+            }
+        }
+    }
+}

--- a/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/MessageRepository.cs
@@ -26,6 +26,7 @@ namespace Doppler.PushContact.WebPushSender.Repositories
             _logger = logger;
         }
 
+        // TODO: registrar la cantidad de consumos facturables aca, y luego obtener el dato desde el mensaje?
         public async Task RegisterStatisticsAsync(Guid messageId, WebPushEvent webPushEvent)
         {
             var sent = 1;

--- a/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
@@ -60,10 +60,23 @@ namespace Doppler.PushContact.WebPushSender.Repositories.Setup
                     .Ascending(WebPushEventDocumentProps.SubType_PropName)
             );
 
+            var index_Domain_Date_Type = new CreateIndexModel<BsonDocument>(
+                indexKeysDefinitionBuilder
+                    .Ascending(WebPushEventDocumentProps.Domain_PropName)
+                    .Ascending(WebPushEventDocumentProps.Date_PropName)
+                    .Ascending(WebPushEventDocumentProps.Type_PropName)
+            );
+
+            var index_DeviceToken = new CreateIndexModel<BsonDocument>(
+                indexKeysDefinitionBuilder.Ascending(WebPushEventDocumentProps.DeviceToken_PropName)
+            );
+
             webPushEventCollection.Indexes.CreateMany([
                 indexModelPushContactId,
                 indexModelMessageIdAndType,
                 indexModel_Domain_Date_Type_SubType,
+                index_Domain_Date_Type,
+                index_DeviceToken,
             ]);
         }
     }

--- a/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using System;
 
 namespace Doppler.PushContact.WebPushSender.Repositories.Setup
 {
@@ -72,12 +73,21 @@ namespace Doppler.PushContact.WebPushSender.Repositories.Setup
                 indexKeysDefinitionBuilder.Ascending(WebPushEventDocumentProps.DeviceToken_PropName)
             );
 
+            var index_Date_TTL = new CreateIndexModel<BsonDocument>(
+                indexKeysDefinitionBuilder.Ascending(WebPushEventDocumentProps.Date_PropName),
+                new CreateIndexOptions
+                {
+                    ExpireAfter = TimeSpan.FromDays(180)
+                }
+            );
+
             webPushEventCollection.Indexes.CreateMany([
                 indexModelPushContactId,
                 indexModelMessageIdAndType,
                 indexModel_Domain_Date_Type_SubType,
                 index_Domain_Date_Type,
                 index_DeviceToken,
+                index_Date_TTL,
             ]);
         }
     }

--- a/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositoryServiceExtensions.cs
@@ -32,6 +32,7 @@ namespace Doppler.PushContact.WebPushSender.Repositories.Setup
 
             services.AddScoped<IWebPushEventRepository, WebPushEventRepository>();
             services.AddScoped<IPushContactRepository, PushContactRepository>();
+            services.AddScoped<IMessageRepository, MessageRepository>();
 
             return services;
         }

--- a/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositorySettings.cs
+++ b/Doppler.PushContact.WebPushSender/Repositories/Setup/RepositorySettings.cs
@@ -17,5 +17,6 @@ namespace Doppler.PushContact.WebPushSender.Repositories.Setup
         public string WebPushEventCollectionName { get; set; }
 
         public string PushContactsCollectionName { get; set; }
+        public string MessageCollectionName { get; set; }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/DefaultWebPushSender.cs
@@ -15,16 +15,20 @@ namespace Doppler.PushContact.WebPushSender.Senders
     public class DefaultWebPushSender : WebPushSenderBase
     {
         IPushContactRepository _pushContactRepository;
+        IMessageRepository _messageRepository;
+
         public DefaultWebPushSender(
             IOptions<WebPushSenderSettings> webPushSenderSettings,
             IMessageQueueSubscriber messageQueueSubscriber,
             ILogger<DefaultWebPushSender> logger,
             IWebPushEventRepository weshPushEventRepository,
-            IPushContactRepository pushContactRepository
+            IPushContactRepository pushContactRepository,
+            IMessageRepository messageRepository
         )
             : base(webPushSenderSettings, messageQueueSubscriber, logger, weshPushEventRepository)
         {
             _pushContactRepository = pushContactRepository;
+            _messageRepository = messageRepository;
         }
 
         public override async Task HandleMessageAsync(DopplerWebPushDTO message)
@@ -84,6 +88,7 @@ namespace Doppler.PushContact.WebPushSender.Senders
             }
 
             await _weshPushEventRepository.InsertAsync(webPushEvent);
+            await _messageRepository.RegisterStatisticsAsync(message.MessageId, webPushEvent);
         }
     }
 }

--- a/Doppler.PushContact.WebPushSender/Senders/WebPushSenderFactory.cs
+++ b/Doppler.PushContact.WebPushSender/Senders/WebPushSenderFactory.cs
@@ -22,6 +22,7 @@ namespace Doppler.PushContact.WebPushSender.Senders
             var loggerFactory = _serviceProvider.GetRequiredService<ILoggerFactory>();
             var webPushEventRepository = _serviceProvider.GetRequiredService<IWebPushEventRepository>();
             var pushContactRepository = _serviceProvider.GetRequiredService<IPushContactRepository>();
+            var messageRepository = _serviceProvider.GetRequiredService<IMessageRepository>();
 
             return webPushSenderSettings.Value.Type switch
             {
@@ -30,14 +31,16 @@ namespace Doppler.PushContact.WebPushSender.Senders
                     messageQueueSubscriber,
                     loggerFactory.CreateLogger<DefaultWebPushSender>(),
                     webPushEventRepository,
-                    pushContactRepository
+                    pushContactRepository,
+                    messageRepository
                 ),
                 _ => new DefaultWebPushSender(
                     webPushSenderSettings,
                     messageQueueSubscriber,
                     loggerFactory.CreateLogger<DefaultWebPushSender>(),
                     webPushEventRepository,
-                    pushContactRepository
+                    pushContactRepository,
+                    messageRepository
                 ),
             };
         }

--- a/Doppler.PushContact.WebPushSender/appsettings.json
+++ b/Doppler.PushContact.WebPushSender/appsettings.json
@@ -23,6 +23,7 @@
   "RepositorySettings": {
     "ConnectionUrl": "REPLACE_FOR_REPOSITORY_CONNECTION_URL",
     "WebPushEventCollectionName": "webPushEvent",
-    "PushContactsCollectionName": "push-contacts"
+    "PushContactsCollectionName": "push-contacts",
+    "MessageCollectionName": "messages"
   }
 }

--- a/Doppler.PushContact/Controllers/MessageController.cs
+++ b/Doppler.PushContact/Controllers/MessageController.cs
@@ -60,7 +60,7 @@ namespace Doppler.PushContact.Controllers
             var message = await _messageRepository.GetMessageDetailsByMessageIdAsync(messageId);
             var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl);
 
-            await _pushContactService.AddHistoryEventsAndMarkDeletedContactsAsync(messageId, sendMessageResult);
+            await _pushContactService.MarkDeletedContactsAsync(messageId, sendMessageResult);
 
             var sent = sendMessageResult.SendMessageTargetResult.Count();
             var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -217,7 +217,7 @@ namespace Doppler.PushContact.Controllers
 
                     var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl, pushApiToken);
 
-                    await _pushContactService.AddHistoryEventsAndMarkDeletedContactsAsync(messageId, sendMessageResult);
+                    await _pushContactService.MarkDeletedContactsAsync(messageId, sendMessageResult);
 
                     var sent = sendMessageResult.SendMessageTargetResult.Count();
                     var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);
@@ -251,7 +251,7 @@ namespace Doppler.PushContact.Controllers
             var sendMessageResult = await _messageSender.SendAsync(message.Title, message.Body, deviceTokens, message.OnClickLink, message.ImageUrl);
 
             var messageId = Guid.NewGuid();
-            await _pushContactService.AddHistoryEventsAndMarkDeletedContactsAsync(messageId, sendMessageResult);
+            await _pushContactService.MarkDeletedContactsAsync(messageId, sendMessageResult);
 
             var sent = sendMessageResult.SendMessageTargetResult.Count();
             var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -264,44 +264,38 @@ namespace Doppler.PushContact.Controllers
             });
         }
 
+        // TODO: remove unused params: from and to
         [HttpGet]
         [Route("push-contacts/{domain}/messages/{messageId}/details")]
         public async Task<IActionResult> GetMessageDetails([FromRoute] string domain, [FromRoute] Guid messageId, [FromQuery][Required] DateTimeOffset from, [FromQuery][Required] DateTimeOffset to)
         {
-            // obtain web push events summarization
-            var webPushEventsSummarization = await _webPushEventService.GetWebPushEventSummarizationAsync(messageId);
-
-            var messageDetailsResponse = new MessageDetailsResponse()
+            var response = new MessageDetailsResponse()
             {
                 Domain = domain,
                 MessageId = messageId,
-                Sent = webPushEventsSummarization.SentQuantity,
-                Delivered = webPushEventsSummarization.Delivered,
-                NotDelivered = webPushEventsSummarization.NotDelivered,
             };
 
-            // obtain summarized result directly from message
-            var messagedetails = await _messageRepository.GetMessageDetailsAsync(domain, messageId);
-            if (messagedetails != null && messagedetails.Sent > 0)
+            try
             {
-                messageDetailsResponse.Sent += messagedetails.Sent;
-                messageDetailsResponse.Delivered += messagedetails.Delivered;
-                messageDetailsResponse.NotDelivered += messagedetails.NotDelivered;
+                var messagedetails = await _messageRepository.GetMessageDetailsAsync(domain, messageId);
+                if (messagedetails != null && messagedetails.Sent > 0)
+                {
+                    response.Sent = messagedetails.Sent;
+                    response.Delivered = messagedetails.Delivered;
+                    response.NotDelivered = messagedetails.NotDelivered;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "An unexpected error occurred obtaining message details. Domain: {domain} and messageId: {messageId}",
+                    domain,
+                    messageId
+                );
             }
 
-            return Ok(messageDetailsResponse);
-
-            // TODO: this should be removed, because the summarization should be obtained always from Message.
-            //// summarize result from history_events
-            //var messageResult = await _pushContactService.GetDeliveredMessageSummarizationAsync(domain, messageId, from, to);
-            //return Ok(new MessageDetailsResponse
-            //{
-            //    Domain = messageResult.Domain,
-            //    MessageId = messageId,
-            //    Sent = messageResult.SentQuantity + webPushEventsSummarization.SentQuantity,
-            //    Delivered = messageResult.Delivered + webPushEventsSummarization.Delivered,
-            //    NotDelivered = messageResult.NotDelivered + webPushEventsSummarization.NotDelivered,
-            //});
+            return Ok(response);
         }
 
         [Obsolete("This endpoint will be deprecated. It will be replaced by 'push-contacts/visitor-guids'.")]

--- a/Doppler.PushContact/Repositories/Interfaces/IWebPushEventRepository.cs
+++ b/Doppler.PushContact/Repositories/Interfaces/IWebPushEventRepository.cs
@@ -2,6 +2,7 @@ using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Models.Entities;
 using Doppler.PushContact.Models.Enums;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,5 +14,6 @@ namespace Doppler.PushContact.Repositories.Interfaces
         Task<bool> InsertAsync(WebPushEvent webPushEvent, CancellationToken cancellationToken);
         Task<bool> IsWebPushEventRegistered(string pushContactId, Guid messageId, WebPushEventType type);
         Task<int> GetWebPushEventConsumed(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
+        Task<int> BulkInsertAsync(IEnumerable<WebPushEvent> webPushEvents);
     }
 }

--- a/Doppler.PushContact/Repositories/WebPushEventRepository.cs
+++ b/Doppler.PushContact/Repositories/WebPushEventRepository.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -186,6 +188,28 @@ namespace Doppler.PushContact.Repositories
                 );
                 throw;
             }
+        }
+
+        public async Task<int> BulkInsertAsync(IEnumerable<WebPushEvent> webPushEvents)
+        {
+            if (webPushEvents == null)
+            {
+                return 0;
+            }
+
+            var documents = webPushEvents.Select(e => e.ToBsonDocument()).ToList();
+
+            if (!documents.Any())
+            {
+                return 0;
+            }
+
+            await WebPushEvents.InsertManyAsync(
+                documents,
+                new InsertManyOptions { IsOrdered = false } // false = no se ejecutan en orden, y si alguna falla, se seguirán ejecutando las restantes
+            );
+
+            return documents.Count;
         }
 
         private IMongoCollection<BsonDocument> WebPushEvents

--- a/Doppler.PushContact/Services/IPushContactService.cs
+++ b/Doppler.PushContact/Services/IPushContactService.cs
@@ -23,7 +23,7 @@ namespace Doppler.PushContact.Services
 
         Task AddHistoryEventsAsync(IEnumerable<PushContactHistoryEvent> pushContactHistoryEvents);
 
-        Task AddHistoryEventsAndMarkDeletedContactsAsync(Guid messageId, SendMessageResult sendMessageResult);
+        Task MarkDeletedContactsAsync(Guid messageId, SendMessageResult sendMessageResult);
 
         Task<IEnumerable<string>> GetAllDeviceTokensByDomainAsync(string domain);
 

--- a/Doppler.PushContact/Services/IWebPushEventService.cs
+++ b/Doppler.PushContact/Services/IWebPushEventService.cs
@@ -11,6 +11,7 @@ namespace Doppler.PushContact.Services
 {
     public interface IWebPushEventService
     {
+        // TODO: revisar este conteo
         Task<WebPushEventSummarizationDTO> GetWebPushEventSummarizationAsync(Guid messageId);
         Task<bool> RegisterWebPushEventAsync(
             string contactId,
@@ -18,6 +19,7 @@ namespace Doppler.PushContact.Services
             WebPushEventType type,
             CancellationToken cancellationToken
         );
+        // TODO: revisar este conteo
         Task<int> GetWebPushEventConsumed(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
         Task<IEnumerable<WebPushEvent>> RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult);
     }

--- a/Doppler.PushContact/Services/IWebPushEventService.cs
+++ b/Doppler.PushContact/Services/IWebPushEventService.cs
@@ -1,7 +1,9 @@
 using Doppler.PushContact.DTOs;
+using Doppler.PushContact.Models.Entities;
 using Doppler.PushContact.Models.Enums;
 using Doppler.PushContact.Services.Messages;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +19,6 @@ namespace Doppler.PushContact.Services
             CancellationToken cancellationToken
         );
         Task<int> GetWebPushEventConsumed(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
-        Task RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult);
+        Task<IEnumerable<WebPushEvent>> RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult);
     }
 }

--- a/Doppler.PushContact/Services/IWebPushEventService.cs
+++ b/Doppler.PushContact/Services/IWebPushEventService.cs
@@ -1,5 +1,6 @@
 using Doppler.PushContact.DTOs;
 using Doppler.PushContact.Models.Enums;
+using Doppler.PushContact.Services.Messages;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,5 +17,6 @@ namespace Doppler.PushContact.Services
             CancellationToken cancellationToken
         );
         Task<int> GetWebPushEventConsumed(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
+        Task RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult);
     }
 }

--- a/Doppler.PushContact/Services/Messages/IMessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageRepository.cs
@@ -1,5 +1,7 @@
 using Doppler.PushContact.ApiModels;
+using Doppler.PushContact.Models.Entities;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Doppler.PushContact.Services.Messages
@@ -19,5 +21,6 @@ namespace Doppler.PushContact.Services.Messages
         Task IncrementMessageStats(Guid messageId, int sent, int delivered, int notDelivered);
         Task<string> GetMessageDomainAsync(Guid messageId);
         Task<int> GetMessageSends(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
+        Task RegisterStatisticsAsync(Guid messageId, IEnumerable<WebPushEvent> webPushEvents);
     }
 }

--- a/Doppler.PushContact/Services/Messages/IMessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageRepository.cs
@@ -16,7 +16,7 @@ namespace Doppler.PushContact.Services.Messages
 
         Task<ApiPage<MessageDeliveryResult>> GetMessages(int page, int per_page, DateTimeOffset from, DateTimeOffset to);
 
-        Task UpdateDeliveriesAsync(Guid messageId, int sent, int delivered, int notDelivered);
+        Task UpdateDeliveriesAsync(Guid messageId, int sent, int delivered, int notDelivered, int billableSends = 0);
 
         Task IncrementMessageStats(Guid messageId, int sent, int delivered, int notDelivered);
         Task<string> GetMessageDomainAsync(Guid messageId);

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -1,4 +1,5 @@
 using Doppler.PushContact.ApiModels;
+using Doppler.PushContact.Models.Entities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -75,6 +75,7 @@ namespace Doppler.PushContact.Services.Messages
             }
         }
 
+        // TODO: registrar la cantidad de consumos facturables aca, y luego obtener el dato desde el mensaje?
         public async Task RegisterStatisticsAsync(Guid messageId, IEnumerable<WebPushEvent> webPushEvents)
         {
             if (webPushEvents == null || !webPushEvents.Any())
@@ -115,7 +116,6 @@ namespace Doppler.PushContact.Services.Messages
             var filterBuilder = Builders<BsonDocument>.Filter;
 
             var filter = filterBuilder.Eq(MessageDocumentProps.DomainPropName, domain);
-
             filter &= filterBuilder.Eq(MessageDocumentProps.MessageIdPropName, new BsonBinaryData(messageId, GuidRepresentation.Standard));
 
             try

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -59,6 +59,7 @@ namespace Doppler.PushContact.Services.Messages
                 { MessageDocumentProps.SentPropName, sent },
                 { MessageDocumentProps.DeliveredPropName, delivered },
                 { MessageDocumentProps.NotDeliveredPropName, notDelivered },
+                { MessageDocumentProps.BillableSendsPropName, 0 },
                 { MessageDocumentProps.ImageUrlPropName, string.IsNullOrEmpty(imageUrl) ? BsonNull.Value : imageUrl},
                 { MessageDocumentProps.InsertedDatePropName, now }
             };
@@ -94,7 +95,7 @@ namespace Doppler.PushContact.Services.Messages
             await UpdateDeliveriesAsync(messageId, sent, delivered, notDelivered, billableSends);
         }
 
-        // TODO: redefine as private when the endpoint accessing this is removed (maybe remove to UpdateDeliveriesSafe)
+        // TODO: redefine as private when the endpoint accessing this is removed (maybe rename to UpdateDeliveriesSafe)
         public async Task UpdateDeliveriesAsync(Guid messageId, int sent, int delivered, int notDelivered, int billableSends = 0)
         {
             var filterDefinition = Builders<BsonDocument>.Filter

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -181,9 +181,9 @@ namespace Doppler.PushContact.Services.Messages
 
                 await _pushContactService.MarkDeletedContactsAsync(webPushDTO.MessageId, sendMessageResult);
 
-                await _webPushEventService.RegisterWebPushEventsAsync(webPushDTO.Domain, webPushDTO.MessageId, sendMessageResult);
+                var webPushEvents = await _webPushEventService.RegisterWebPushEventsAsync(webPushDTO.Domain, webPushDTO.MessageId, sendMessageResult);
 
-                await RegisterStatisticsAsync(webPushDTO.MessageId, sendMessageResult);
+                await _messageRepository.RegisterStatisticsAsync(webPushDTO.MessageId, webPushEvents);
             }
             catch (ArgumentException argEx)
             {
@@ -203,15 +203,6 @@ namespace Doppler.PushContact.Services.Messages
                     webPushDTO.MessageId
                 );
             }
-        }
-
-        private async Task RegisterStatisticsAsync(Guid messageId, SendMessageResult sendMessageResult)
-        {
-            var sent = sendMessageResult.SendMessageTargetResult.Count();
-            var delivered = sendMessageResult.SendMessageTargetResult.Count(x => x.IsSuccess);
-            var notDelivered = sent - delivered;
-
-            await _messageRepository.UpdateDeliveriesAsync(messageId, sent, delivered, notDelivered);
         }
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -179,7 +179,7 @@ namespace Doppler.PushContact.Services.Messages
                     authenticationApiToken
                 );
 
-                await _pushContactService.AddHistoryEventsAndMarkDeletedContactsAsync(webPushDTO.MessageId, sendMessageResult);
+                await _pushContactService.MarkDeletedContactsAsync(webPushDTO.MessageId, sendMessageResult);
 
                 await _webPushEventService.RegisterWebPushEventsAsync(webPushDTO.Domain, webPushDTO.MessageId, sendMessageResult);
 

--- a/Doppler.PushContact/Services/Messages/MessageSender.cs
+++ b/Doppler.PushContact/Services/Messages/MessageSender.cs
@@ -17,6 +17,7 @@ namespace Doppler.PushContact.Services.Messages
         private readonly IPushApiTokenGetter _pushApiTokenGetter;
         private readonly IMessageRepository _messageRepository;
         private readonly IPushContactService _pushContactService;
+        private readonly IWebPushEventService _webPushEventService;
         private readonly ILogger<MessageSender> _logger;
 
         public MessageSender(
@@ -24,6 +25,7 @@ namespace Doppler.PushContact.Services.Messages
             IPushApiTokenGetter pushApiTokenGetter,
             IMessageRepository messageRepository,
             IPushContactService pushContactService,
+            IWebPushEventService webPushEventService,
             ILogger<MessageSender> logger
         )
         {
@@ -31,6 +33,7 @@ namespace Doppler.PushContact.Services.Messages
             _pushApiTokenGetter = pushApiTokenGetter;
             _messageRepository = messageRepository;
             _pushContactService = pushContactService;
+            _webPushEventService = webPushEventService;
             _logger = logger;
         }
 
@@ -177,6 +180,8 @@ namespace Doppler.PushContact.Services.Messages
                 );
 
                 await _pushContactService.AddHistoryEventsAndMarkDeletedContactsAsync(webPushDTO.MessageId, sendMessageResult);
+
+                await _webPushEventService.RegisterWebPushEventsAsync(webPushDTO.Domain, webPushDTO.MessageId, sendMessageResult);
 
                 await RegisterStatisticsAsync(webPushDTO.MessageId, sendMessageResult);
             }

--- a/Doppler.PushContact/Services/PushContactService.cs
+++ b/Doppler.PushContact/Services/PushContactService.cs
@@ -292,6 +292,7 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
+        // TODO: remove this method. Now, the history_events should not be considered as subdocuments of push-contacts anymore.
         public async Task AddHistoryEventsAsync(IEnumerable<PushContactHistoryEvent> pushContactHistoryEvents)
         {
             if (pushContactHistoryEvents == null || !pushContactHistoryEvents.Any())
@@ -334,10 +335,8 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             }
         }
 
-        // TODO: If we decide not to register more history events, rename this method properly: MarkDeletedContactsAsync.
-        public async Task AddHistoryEventsAndMarkDeletedContactsAsync(Guid messageId, SendMessageResult sendMessageResult)
+        public async Task MarkDeletedContactsAsync(Guid messageId, SendMessageResult sendMessageResult)
         {
-            //TO DO: implement abstraction
             if (sendMessageResult == null)
             {
                 throw new ArgumentNullException($"{typeof(SendMessageResult)} cannot be null");
@@ -351,25 +350,6 @@ with {nameof(deviceToken)} {deviceToken}. {PushContactDocumentProps.EmailPropNam
             if (notValidTargetDeviceToken != null && notValidTargetDeviceToken.Any())
             {
                 await DeleteByDeviceTokenAsync(notValidTargetDeviceToken);
-            }
-
-            var now = DateTime.UtcNow;
-
-            var pushContactHistoryEvents = sendMessageResult
-                .SendMessageTargetResult?
-                .Select(x => new PushContactHistoryEvent
-                {
-                    DeviceToken = x.TargetDeviceToken,
-                    SentSuccess = x.IsSuccess,
-                    EventDate = now,
-                    Details = x.NotSuccessErrorDetails,
-                    MessageId = messageId
-                });
-
-            if (pushContactHistoryEvents != null && pushContactHistoryEvents.Any())
-            {
-                // TODO: registering in historyevents isn't scalable. If it's necessary consider an alternative. Otherwise, delete it.
-                //await AddHistoryEventsAsync(pushContactHistoryEvents);
             }
         }
 

--- a/Doppler.PushContact/Services/WebPushEventService.cs
+++ b/Doppler.PushContact/Services/WebPushEventService.cs
@@ -100,11 +100,7 @@ namespace Doppler.PushContact.Services
 
         public async Task<int> GetWebPushEventConsumed(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo)
         {
-            // TODO: it's due to the differences between Doppler and Firebase implementations. It should be unified.
-            var consumedFromWebPushEvents = await _webPushEventRepository.GetWebPushEventConsumed(domain, dateFrom, dateTo);
-            var consumedFromMessages = await _messageRepository.GetMessageSends(domain, dateFrom, dateTo);
-
-            return consumedFromWebPushEvents + consumedFromMessages;
+            return await _webPushEventRepository.GetWebPushEventConsumed(domain, dateFrom, dateTo);
         }
 
         public async Task<IEnumerable<WebPushEvent>> RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult)

--- a/Doppler.PushContact/Services/WebPushEventService.cs
+++ b/Doppler.PushContact/Services/WebPushEventService.cs
@@ -5,6 +5,7 @@ using Doppler.PushContact.Repositories.Interfaces;
 using Doppler.PushContact.Services.Messages;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -106,11 +107,11 @@ namespace Doppler.PushContact.Services
             return consumedFromWebPushEvents + consumedFromMessages;
         }
 
-        public async Task RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult)
+        public async Task<IEnumerable<WebPushEvent>> RegisterWebPushEventsAsync(string domain, Guid messageId, SendMessageResult sendMessageResult)
         {
             if (sendMessageResult == null)
             {
-                return;
+                return null;
             }
 
             var webPushEvents = sendMessageResult.SendMessageTargetResult?
@@ -142,7 +143,11 @@ namespace Doppler.PushContact.Services
                         messageId
                     );
                 }
+
+                return webPushEvents;
             }
+
+            return null;
         }
     }
 }

--- a/Doppler.PushContact/Services/WebPushEventService.cs
+++ b/Doppler.PushContact/Services/WebPushEventService.cs
@@ -112,16 +112,16 @@ namespace Doppler.PushContact.Services
 
             var webPushEvents = sendMessageResult.SendMessageTargetResult?
                 .Select(sendResult => new WebPushEvent
-                    {
-                        Domain = domain,
-                        MessageId = messageId,
-                        DeviceToken = sendResult.TargetDeviceToken,
-                        Date = DateTime.UtcNow,
-                        Type = sendResult.IsSuccess ? (int)WebPushEventType.Delivered : (int)WebPushEventType.DeliveryFailed,
-                        SubType = sendResult.IsSuccess ? (int)WebPushEventSubType.None :
+                {
+                    Domain = domain,
+                    MessageId = messageId,
+                    DeviceToken = sendResult.TargetDeviceToken,
+                    Date = DateTime.UtcNow,
+                    Type = sendResult.IsSuccess ? (int)WebPushEventType.Delivered : (int)WebPushEventType.DeliveryFailed,
+                    SubType = sendResult.IsSuccess ? (int)WebPushEventSubType.None :
                             sendResult.IsValidTargetDeviceToken ? (int)WebPushEventSubType.UnknownFailure : (int)WebPushEventSubType.InvalidSubcription,
-                        ErrorMessage = sendResult.NotSuccessErrorDetails,
-                    }
+                    ErrorMessage = sendResult.NotSuccessErrorDetails,
+                }
                 );
 
             if (webPushEvents != null && webPushEvents.Any())


### PR DESCRIPTION
Se unifican los `history_events` con la collection `webpushevents`. Los `history_events` (subdocumentos de `push-contacts`) que se registraban a partir de un envio de **Firebase**, ahora serán registrados en la collection `webpushevents` que almacena los envios de **Doppler**.

Cambios realizados:
- al hacer un envio con Firebase, se registraran los resultados en `webpushevents` (continua sumarizandose en `messages` los totales)
- al hacer un envio con Doppler, se registran los totales en la collection de `messages`
- para ambos casos se contabiliza en `messages` un nuevo valor `billable_sends`, son los envios facturables (por ahora los **entregados correctamente y los fallidos porque el deviceToken era invalido**)
- el reporte de un mensaje se obtiene integro desde los totales de la collection `messages` (antes los totales de **Doppler** se contabilizaban desde `webpushevents`, y los totales de **Firebase** se obtenian de los totales de `messages`).
- los consumidos se obtienen contabilizando los `webpushevents` (antes los consumidos de **Doppler** se contabilizaban desde `webpushevents`, y los consumidos de **Firebase** se obtenian de los totales de `messages`).
- se mejoró la query para calcular consumidos, dado que siempre tendrá que hacer un conteo (verificar esta query en prod cuando este cargada la collection de `webpushevents`).
- se agregó un **indice TTL en `webpushevents`** para eliminar registros automaticamente **despues de 180 dias**

TODO: agregar tests