### PR TITLE
Dop 1895 include clicks n receives in message details endpoint

### DIFF
--- a/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
+++ b/Doppler.PushContact.Models/Entities/MessageDocumentProps.cs
@@ -25,5 +25,7 @@ namespace Doppler.PushContact.Models.Entities
         public const string ImageUrlPropName = "image_url";
 
         public const string BillableSendsPropName = "billable_sends";
+        public const string ClicksPropName = "clicks";
+        public const string ReceivedPropName = "received";
     }
 }

--- a/Doppler.PushContact.Models/PushContactApiResponses/MessageDetailsResponse.cs
+++ b/Doppler.PushContact.Models/PushContactApiResponses/MessageDetailsResponse.cs
@@ -9,5 +9,8 @@ namespace Doppler.PushContact.Models.PushContactApiResponses
         public int Sent { get; set; }
         public int Delivered { get; set; }
         public int NotDelivered { get; set; }
+        public int BillableSends { get; set; }
+        public int Clicks { get; set; }
+        public int Received { get; set; }
     }
 }

--- a/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
+++ b/Doppler.PushContact.Test/Controllers/DomainControllerTest.cs
@@ -3,6 +3,7 @@ using Doppler.PushContact.Models;
 using Doppler.PushContact.Models.DTOs;
 using Doppler.PushContact.Models.Models;
 using Doppler.PushContact.Services;
+using Doppler.PushContact.Services.Messages;
 using Doppler.PushContact.Test.Controllers.Utils;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -144,6 +145,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -220,6 +222,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -257,6 +260,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -295,6 +299,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -332,6 +337,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -419,6 +425,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -458,6 +465,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -507,6 +515,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -549,6 +558,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -584,6 +594,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -620,6 +631,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -665,6 +677,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
 
             }).CreateClient(new WebApplicationFactoryClientOptions());
@@ -765,6 +778,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
@@ -819,6 +833,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
@@ -859,6 +874,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(new Mock<IMessageService>().Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
@@ -938,6 +954,7 @@ namespace Doppler.PushContact.Test.Controllers
             var to = DateTime.UtcNow;
 
             var domainServiceMock = new Mock<IDomainService>();
+            var messageServiceMock = new Mock<IMessageService>();
 
             var webPushEventServiceMock = new Mock<IWebPushEventService>();
             webPushEventServiceMock.Setup(x => x.GetWebPushEventConsumed(domain, It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
@@ -949,6 +966,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(messageServiceMock.Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 
@@ -980,6 +998,7 @@ namespace Doppler.PushContact.Test.Controllers
             var expectedConsumed = 11;
 
             var domainServiceMock = new Mock<IDomainService>();
+            var messageServiceMock = new Mock<IMessageService>();
 
             var webPushEventServiceMock = new Mock<IWebPushEventService>();
             webPushEventServiceMock.Setup(x => x.GetWebPushEventConsumed(domain, It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>()))
@@ -991,6 +1010,7 @@ namespace Doppler.PushContact.Test.Controllers
                 {
                     services.AddSingleton(domainServiceMock.Object);
                     services.AddSingleton(webPushEventServiceMock.Object);
+                    services.AddSingleton(messageServiceMock.Object);
                 });
             }).CreateClient(new WebApplicationFactoryClientOptions());
 

--- a/Doppler.PushContact/Controllers/PushContactController.cs
+++ b/Doppler.PushContact/Controllers/PushContactController.cs
@@ -264,7 +264,7 @@ namespace Doppler.PushContact.Controllers
             });
         }
 
-        // TODO: remove unused params: from and to
+        [Obsolete("This endpoint is deprecated. It will be replaced by 'domains/{domain}/messages/{messageId}/stats'.")]
         [HttpGet]
         [Route("push-contacts/{domain}/messages/{messageId}/details")]
         public async Task<IActionResult> GetMessageDetails([FromRoute] string domain, [FromRoute] Guid messageId, [FromQuery][Required] DateTimeOffset from, [FromQuery][Required] DateTimeOffset to)

--- a/Doppler.PushContact/Services/Messages/IMessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageRepository.cs
@@ -22,5 +22,6 @@ namespace Doppler.PushContact.Services.Messages
         Task<string> GetMessageDomainAsync(Guid messageId);
         Task<int> GetMessageSends(string domain, DateTimeOffset dateFrom, DateTimeOffset dateTo);
         Task RegisterStatisticsAsync(Guid messageId, IEnumerable<WebPushEvent> webPushEvents);
+        Task RegisterEventCount(Guid messageId, WebPushEvent webPushEvent);
     }
 }

--- a/Doppler.PushContact/Services/Messages/IMessageService.cs
+++ b/Doppler.PushContact/Services/Messages/IMessageService.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public interface IMessageService
+    {
+        Task<MessageDetails> GetMessageStatsAsync(string domain, Guid messageId);
+    }
+}

--- a/Doppler.PushContact/Services/Messages/MessageDetails.cs
+++ b/Doppler.PushContact/Services/Messages/MessageDetails.cs
@@ -21,5 +21,8 @@ namespace Doppler.PushContact.Services.Messages
         public int NotDelivered { get; set; }
 
         public string ImageUrl { get; set; }
+        public int BillableSends { get; set; }
+        public int Clicks { get; set; }
+        public int Received { get; set; }
     }
 }

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -204,6 +204,9 @@ namespace Doppler.PushContact.Services.Messages
                     Sent = message.GetValue(MessageDocumentProps.SentPropName).AsInt32,
                     Delivered = message.GetValue(MessageDocumentProps.DeliveredPropName).AsInt32,
                     NotDelivered = message.GetValue(MessageDocumentProps.NotDeliveredPropName).AsInt32,
+                    BillableSends = message.GetValue(MessageDocumentProps.BillableSendsPropName, 0).ToInt32(),
+                    Clicks = message.GetValue(MessageDocumentProps.ClicksPropName, 0).ToInt32(),
+                    Received = message.GetValue(MessageDocumentProps.ReceivedPropName, 0).ToInt32(),
                 };
 
                 if (message.TryGetValue(MessageDocumentProps.OnClickLinkPropName, out BsonValue onClickLinkValue))

--- a/Doppler.PushContact/Services/Messages/MessageRepository.cs
+++ b/Doppler.PushContact/Services/Messages/MessageRepository.cs
@@ -60,6 +60,8 @@ namespace Doppler.PushContact.Services.Messages
                 { MessageDocumentProps.DeliveredPropName, delivered },
                 { MessageDocumentProps.NotDeliveredPropName, notDelivered },
                 { MessageDocumentProps.BillableSendsPropName, 0 },
+                { MessageDocumentProps.ReceivedPropName, 0 },
+                { MessageDocumentProps.ClicksPropName, 0 },
                 { MessageDocumentProps.ImageUrlPropName, string.IsNullOrEmpty(imageUrl) ? BsonNull.Value : imageUrl},
                 { MessageDocumentProps.InsertedDatePropName, now }
             };

--- a/Doppler.PushContact/Services/Messages/MessageService.cs
+++ b/Doppler.PushContact/Services/Messages/MessageService.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Doppler.PushContact.Services.Messages
+{
+    public class MessageService : IMessageService
+    {
+        private readonly IMessageRepository _messageRepository;
+        private readonly ILogger<MessageService> _logger;
+
+        public MessageService(IMessageRepository messageRepository, ILogger<MessageService> logger)
+        {
+            _messageRepository = messageRepository;
+            _logger = logger;
+        }
+
+        public async Task<MessageDetails> GetMessageStatsAsync(string domain, Guid messageId)
+        {
+            return await _messageRepository.GetMessageDetailsAsync(domain, messageId);
+        }
+    }
+}

--- a/Doppler.PushContact/Services/WebPushEventService.cs
+++ b/Doppler.PushContact/Services/WebPushEventService.cs
@@ -81,6 +81,8 @@ namespace Doppler.PushContact.Services
                     Type = (int)type,
                     Domain = contactDomain,
                 };
+
+                await _messageRepository.RegisterEventCount(messageId, webPushEvent);
                 await _webPushEventRepository.InsertAsync(webPushEvent, cancellationToken);
             }
             catch (Exception ex)

--- a/Doppler.PushContact/Startup.cs
+++ b/Doppler.PushContact/Startup.cs
@@ -47,6 +47,7 @@ namespace Doppler.PushContact
             services.AddScoped<IPushContactRepository, PushContactRepository>();
             services.AddScoped<IDomainRepository, DomainRepository>();
             services.AddScoped<IWebPushEventService, WebPushEventService>();
+            services.AddScoped<IMessageService, MessageService>();
             services.AddSingleton<IBackgroundQueue, BackgroundQueue>();
             services.AddHostedService<QueueBackgroundService>();
             services.AddControllers();


### PR DESCRIPTION
- Agregar el conteo de clicks y recibidos en el mensaje.
- Deprecar viejo endpoint: `push-contacts/{domain}/messages/{messageId}/details`
- Agregar nuevo endpoint: `domains/{domain}/messages/{messageId}/stats`, el cual devuelve las nuevas estadisticas siendo contabilizadas.

**MISSING:** agregar unit tests